### PR TITLE
Minor HTML tweak

### DIFF
--- a/A.html
+++ b/A.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="split chapter"><head><meta charset="utf-8"><title>Annex A (informative) Grammar Summary # &#9417; &#9402; &#9312; &#9398; &#8212; Annotated ES5</title><link rel="stylesheet" href="style.css"><link rel="shortcut icon" href="favicon.ico"><link href="x16.html" title="16 Errors " rel="prev">
+<html class="split chapter"><head><meta charset="utf-8"><title>Annex A (informative) Grammar Summary # &#9417; &#9402; &#9312; &#9398; &#8212; Annotated ES5</title><link rel="stylesheet" href="style.css"><link href="x16.html" title="16 Errors " rel="prev">
   <link href="spec.html#contents" title="TOC" rel="index">
   <link href="B.html" title="Annex B (informative) Compatibility " rel="next">
   </head><body><div class="head">

--- a/B.html
+++ b/B.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="split chapter"><head><meta charset="utf-8"><title>Annex B (informative) Compatibility # &#9417; &#9402; &#9312; &#9398; &#8212; Annotated ES5</title><link rel="stylesheet" href="style.css"><link rel="shortcut icon" href="favicon.ico"><link href="A.html" title="Annex A (informative) Grammar Summary " rel="prev">
+<html class="split chapter"><head><meta charset="utf-8"><title>Annex B (informative) Compatibility # &#9417; &#9402; &#9312; &#9398; &#8212; Annotated ES5</title><link rel="stylesheet" href="style.css"><link href="A.html" title="Annex A (informative) Grammar Summary " rel="prev">
   <link href="spec.html#contents" title="TOC" rel="index">
   <link href="C.html" title="Annex C (informative) The Strict Mode of ECMAScript " rel="next">
   </head><body><div class="head">

--- a/C.html
+++ b/C.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="split chapter"><head><meta charset="utf-8"><title>Annex C (informative) The Strict Mode of ECMAScript # &#9417; &#9402; &#9312; &#9398; &#8212; Annotated ES5</title><link rel="stylesheet" href="style.css"><link rel="shortcut icon" href="favicon.ico"><link href="B.html" title="Annex B (informative) Compatibility " rel="prev">
+<html class="split chapter"><head><meta charset="utf-8"><title>Annex C (informative) The Strict Mode of ECMAScript # &#9417; &#9402; &#9312; &#9398; &#8212; Annotated ES5</title><link rel="stylesheet" href="style.css"><link href="B.html" title="Annex B (informative) Compatibility " rel="prev">
   <link href="spec.html#contents" title="TOC" rel="index">
   <link href="D.html" title="Annex D (informative) Corrections and Clarifications in the 5th Edition with Possible 3rd Edition Compatibility Impact " rel="next">
   </head><body><div class="head">

--- a/D.html
+++ b/D.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="split chapter"><head><meta charset="utf-8"><title>Annex D (informative) Corrections and Clarifications in the 5th Edition with Possible 3rd Edition Compatibility Impact # &#9417; &#9402; &#9312; &#9398; &#8212; Annotated ES5</title><link rel="stylesheet" href="style.css"><link rel="shortcut icon" href="favicon.ico"><link href="C.html" title="Annex C (informative) The Strict Mode of ECMAScript " rel="prev">
+<html class="split chapter"><head><meta charset="utf-8"><title>Annex D (informative) Corrections and Clarifications in the 5th Edition with Possible 3rd Edition Compatibility Impact # &#9417; &#9402; &#9312; &#9398; &#8212; Annotated ES5</title><link rel="stylesheet" href="style.css"><link href="C.html" title="Annex C (informative) The Strict Mode of ECMAScript " rel="prev">
   <link href="spec.html#contents" title="TOC" rel="index">
   <link href="E.html" title="Annex E (informative) Additions and Changes in the 5th Edition that Introduce Incompatibilities with the 3rd Edition " rel="next">
   </head><body><div class="head">

--- a/E.html
+++ b/E.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="split chapter"><head><meta charset="utf-8"><title>Annex E (informative) Additions and Changes in the 5th Edition that Introduce Incompatibilities with the 3rd Edition # &#9417; &#9402; &#9312; &#9398; &#8212; Annotated ES5</title><link rel="stylesheet" href="style.css"><link rel="shortcut icon" href="favicon.ico"><link href="D.html" title="Annex D (informative) Corrections and Clarifications in the 5th Edition with Possible 3rd Edition Compatibility Impact " rel="prev">
+<html class="split chapter"><head><meta charset="utf-8"><title>Annex E (informative) Additions and Changes in the 5th Edition that Introduce Incompatibilities with the 3rd Edition # &#9417; &#9402; &#9312; &#9398; &#8212; Annotated ES5</title><link rel="stylesheet" href="style.css"><link href="D.html" title="Annex D (informative) Corrections and Clarifications in the 5th Edition with Possible 3rd Edition Compatibility Impact " rel="prev">
   <link href="spec.html#contents" title="TOC" rel="index">
   <link href="bibliography.html" title="Bibliography " rel="next">
   </head><body><div class="head">

--- a/bibliography.html
+++ b/bibliography.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="split chapter"><head><meta charset="utf-8"><title>Bibliography # &#9417; &#9402; &#9312; &#9398; &#8212; Annotated ES5</title><link rel="stylesheet" href="style.css"><link rel="shortcut icon" href="favicon.ico"><link href="E.html" title="Annex E (informative) Additions and Changes in the 5th Edition that Introduce Incompatibilities with the 3rd Edition " rel="prev">
+<html class="split chapter"><head><meta charset="utf-8"><title>Bibliography # &#9417; &#9402; &#9312; &#9398; &#8212; Annotated ES5</title><link rel="stylesheet" href="style.css"><link href="E.html" title="Annex E (informative) Additions and Changes in the 5th Edition that Introduce Incompatibilities with the 3rd Edition " rel="prev">
   <link href="spec.html#contents" title="TOC" rel="index">
   </head><body><div class="head">
 <h2 id="top">Annotated ECMAScript 5.1 <span id="timestamp"></span></h2>

--- a/index.html
+++ b/index.html
@@ -1,9 +1,9 @@
-<!doctype html>
+<!DOCTYPE html>
 <html><head>
   <meta charset="utf-8">
   <title>Annotated ES5</title>
   <link rel="stylesheet" href="style.css">
-  <link rel="shortcut icon" href="favicon.ico">
+  
 </head>
 <body>
 <div id="prolog">

--- a/introduction.html
+++ b/introduction.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="split chapter"><head><meta charset="utf-8"><title>Introduction # &#9417; &#9402; &#9312; &#9398; &#8212; Annotated ES5</title><link rel="stylesheet" href="style.css"><link rel="shortcut icon" href="favicon.ico"><link href="spec.html#contents" title="TOC" rel="index">
+<html class="split chapter"><head><meta charset="utf-8"><title>Introduction # &#9417; &#9402; &#9312; &#9398; &#8212; Annotated ES5</title><link rel="stylesheet" href="style.css"><link href="spec.html#contents" title="TOC" rel="index">
   <link href="x1.html" title="1 Scope " rel="next">
   </head><body><div class="head">
 <h2 id="top">Annotated ECMAScript 5.1 <span id="timestamp"></span></h2>

--- a/key.html
+++ b/key.html
@@ -1,9 +1,8 @@
-<!doctype html>
+<!DOCTYPE html>
 <html><head>
   <meta charset="utf-8">
   <title>Annotated ES5: Key to the annotations</title>
   <link rel="stylesheet" href="style.css">
-  <link rel="shortcut icon" href="favicon.ico">
 </head>
 <body>
 <div id="prolog">

--- a/spec.html
+++ b/spec.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="split index"><head><meta charset="utf-8"><title>Annotated ES5</title><link rel="stylesheet" href="style.css"><link rel="shortcut icon" href="favicon.ico"></head><body><div id="prolog">
+<html class="split index"><head><meta charset="utf-8"><title>Annotated ES5</title><link rel="stylesheet" href="style.css"></head><body><div id="prolog">
 <div class="head">
 <h2 id="top">Annotated ECMAScript 5.1 <span id="timestamp"></span></h2>
 <div id="mascot-treehouse">

--- a/x1.html
+++ b/x1.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="split chapter"><head><meta charset="utf-8"><title>1 Scope # &#9417; &#9402; &#9312; &#9398; &#8212; Annotated ES5</title><link rel="stylesheet" href="style.css"><link rel="shortcut icon" href="favicon.ico"><link href="introduction.html" title="Introduction " rel="prev">
+<html class="split chapter"><head><meta charset="utf-8"><title>1 Scope # &#9417; &#9402; &#9312; &#9398; &#8212; Annotated ES5</title><link rel="stylesheet" href="style.css"><link href="introduction.html" title="Introduction" rel="prev">
   <link href="spec.html#contents" title="TOC" rel="index">
   <link href="x2.html" title="2 Conformance " rel="next">
   </head><body><div class="head">

--- a/x10.html
+++ b/x10.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="split chapter"><head><meta charset="utf-8"><title>10 Executable Code and Execution Contexts # &#9417; &#9402; &#9312; &#9398; &#8212; Annotated ES5</title><link rel="stylesheet" href="style.css"><link rel="shortcut icon" href="favicon.ico"><link href="x9.html" title="9 Type Conversion and Testing " rel="prev">
+<html class="split chapter"><head><meta charset="utf-8"><title>10 Executable Code and Execution Contexts # &#9417; &#9402; &#9312; &#9398; &#8212; Annotated ES5</title><link rel="stylesheet" href="style.css"><link href="x9.html" title="9 Type Conversion and Testing " rel="prev">
   <link href="spec.html#contents" title="TOC" rel="index">
   <link href="x11.html" title="11 Expressions " rel="next">
   </head><body><div class="head">

--- a/x11.html
+++ b/x11.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="split chapter"><head><meta charset="utf-8"><title>11 Expressions # &#9417; &#9402; &#9312; &#9398; &#8212; Annotated ES5</title><link rel="stylesheet" href="style.css"><link rel="shortcut icon" href="favicon.ico"><link href="x10.html" title="10 Executable Code and Execution Contexts " rel="prev">
+<html class="split chapter"><head><meta charset="utf-8"><title>11 Expressions # &#9417; &#9402; &#9312; &#9398; &#8212; Annotated ES5</title><link rel="stylesheet" href="style.css"><link href="x10.html" title="10 Executable Code and Execution Contexts " rel="prev">
   <link href="spec.html#contents" title="TOC" rel="index">
   <link href="x12.html" title="12 Statements " rel="next">
   </head><body><div class="head">

--- a/x12.html
+++ b/x12.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="split chapter"><head><meta charset="utf-8"><title>12 Statements # &#9417; &#9402; &#9312; &#9398; &#8212; Annotated ES5</title><link rel="stylesheet" href="style.css"><link rel="shortcut icon" href="favicon.ico"><link href="x11.html" title="11 Expressions " rel="prev">
+<html class="split chapter"><head><meta charset="utf-8"><title>12 Statements # &#9417; &#9402; &#9312; &#9398; &#8212; Annotated ES5</title><link rel="stylesheet" href="style.css"><link href="x11.html" title="11 Expressions " rel="prev">
   <link href="spec.html#contents" title="TOC" rel="index">
   <link href="x13.html" title="13 Function Definition " rel="next">
   </head><body><div class="head">

--- a/x13.html
+++ b/x13.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="split chapter"><head><meta charset="utf-8"><title>13 Function Definition # &#9417; &#9402; &#9312; &#9398; &#8212; Annotated ES5</title><link rel="stylesheet" href="style.css"><link rel="shortcut icon" href="favicon.ico"><link href="x12.html" title="12 Statements " rel="prev">
+<html class="split chapter"><head><meta charset="utf-8"><title>13 Function Definition # &#9417; &#9402; &#9312; &#9398; &#8212; Annotated ES5</title><link rel="stylesheet" href="style.css"><link href="x12.html" title="12 Statements " rel="prev">
   <link href="spec.html#contents" title="TOC" rel="index">
   <link href="x14.html" title="14 Program " rel="next">
   </head><body><div class="head">

--- a/x14.html
+++ b/x14.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="split chapter"><head><meta charset="utf-8"><title>14 Program # &#9417; &#9402; &#9312; &#9398; &#8212; Annotated ES5</title><link rel="stylesheet" href="style.css"><link rel="shortcut icon" href="favicon.ico"><link href="x13.html" title="13 Function Definition " rel="prev">
+<html class="split chapter"><head><meta charset="utf-8"><title>14 Program # &#9417; &#9402; &#9312; &#9398; &#8212; Annotated ES5</title><link rel="stylesheet" href="style.css"><link href="x13.html" title="13 Function Definition " rel="prev">
   <link href="spec.html#contents" title="TOC" rel="index">
   <link href="x15.html" title="15 Standard Built-in ECMAScript Objects " rel="next">
   </head><body><div class="head">

--- a/x15.1.html
+++ b/x15.1.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="split chapter"><head><meta charset="utf-8"><title>15.1 The Global Object # &#9417; &#9402; &#9312; &#9398; &#8212; Annotated ES5</title><link rel="stylesheet" href="style.css"><link rel="shortcut icon" href="favicon.ico"><link href="x15.html" title="15 Standard Built-in ECMAScript Objects " rel="prev">
+<html class="split chapter"><head><meta charset="utf-8"><title>15.1 The Global Object # &#9417; &#9402; &#9312; &#9398; &#8212; Annotated ES5</title><link rel="stylesheet" href="style.css"><link href="x15.html" title="15 Standard Built-in ECMAScript Objects " rel="prev">
   <link href="spec.html#contents" title="TOC" rel="index">
   <link href="x15.2.html" title="15.2 Object Objects " rel="next">
   </head><body><div class="head">

--- a/x15.10.html
+++ b/x15.10.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="split chapter"><head><meta charset="utf-8"><title>15.10 RegExp (Regular Expression) Objects # &#9417; &#9402; &#9312; &#9398; &#8212; Annotated ES5</title><link rel="stylesheet" href="style.css"><link rel="shortcut icon" href="favicon.ico"><link href="x15.9.html" title="15.9 Date Objects " rel="prev">
+<html class="split chapter"><head><meta charset="utf-8"><title>15.10 RegExp (Regular Expression) Objects # &#9417; &#9402; &#9312; &#9398; &#8212; Annotated ES5</title><link rel="stylesheet" href="style.css"><link href="x15.9.html" title="15.9 Date Objects " rel="prev">
   <link href="spec.html#contents" title="TOC" rel="index">
   <link href="x15.11.html" title="15.11 Error Objects " rel="next">
   </head><body><div class="head">

--- a/x15.11.html
+++ b/x15.11.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="split chapter"><head><meta charset="utf-8"><title>15.11 Error Objects # &#9417; &#9402; &#9312; &#9398; &#8212; Annotated ES5</title><link rel="stylesheet" href="style.css"><link rel="shortcut icon" href="favicon.ico"><link href="x15.10.html" title="15.10 RegExp (Regular Expression) Objects " rel="prev">
+<html class="split chapter"><head><meta charset="utf-8"><title>15.11 Error Objects # &#9417; &#9402; &#9312; &#9398; &#8212; Annotated ES5</title><link rel="stylesheet" href="style.css"><link href="x15.10.html" title="15.10 RegExp (Regular Expression) Objects " rel="prev">
   <link href="spec.html#contents" title="TOC" rel="index">
   <link href="x15.12.html" title="15.12 The JSON Object " rel="next">
   </head><body><div class="head">

--- a/x15.12.html
+++ b/x15.12.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="split chapter"><head><meta charset="utf-8"><title>15.12 The JSON Object # &#9417; &#9402; &#9312; &#9398; &#8212; Annotated ES5</title><link rel="stylesheet" href="style.css"><link rel="shortcut icon" href="favicon.ico"><link href="x15.11.html" title="15.11 Error Objects " rel="prev">
+<html class="split chapter"><head><meta charset="utf-8"><title>15.12 The JSON Object # &#9417; &#9402; &#9312; &#9398; &#8212; Annotated ES5</title><link rel="stylesheet" href="style.css"><link href="x15.11.html" title="15.11 Error Objects " rel="prev">
   <link href="spec.html#contents" title="TOC" rel="index">
   <link href="x16.html" title="16 Errors " rel="next">
   </head><body><div class="head">

--- a/x15.2.html
+++ b/x15.2.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="split chapter"><head><meta charset="utf-8"><title>15.2 Object Objects # &#9417; &#9402; &#9312; &#9398; &#8212; Annotated ES5</title><link rel="stylesheet" href="style.css"><link rel="shortcut icon" href="favicon.ico"><link href="x15.1.html" title="15.1 The Global Object " rel="prev">
+<html class="split chapter"><head><meta charset="utf-8"><title>15.2 Object Objects # &#9417; &#9402; &#9312; &#9398; &#8212; Annotated ES5</title><link rel="stylesheet" href="style.css"><link href="x15.1.html" title="15.1 The Global Object " rel="prev">
   <link href="spec.html#contents" title="TOC" rel="index">
   <link href="x15.3.html" title="15.3 Function Objects " rel="next">
   </head><body><div class="head">

--- a/x15.3.html
+++ b/x15.3.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="split chapter"><head><meta charset="utf-8"><title>15.3 Function Objects # &#9417; &#9402; &#9312; &#9398; &#8212; Annotated ES5</title><link rel="stylesheet" href="style.css"><link rel="shortcut icon" href="favicon.ico"><link href="x15.2.html" title="15.2 Object Objects " rel="prev">
+<html class="split chapter"><head><meta charset="utf-8"><title>15.3 Function Objects # &#9417; &#9402; &#9312; &#9398; &#8212; Annotated ES5</title><link rel="stylesheet" href="style.css"><link href="x15.2.html" title="15.2 Object Objects " rel="prev">
   <link href="spec.html#contents" title="TOC" rel="index">
   <link href="x15.4.html" title="15.4 Array Objects " rel="next">
   </head><body><div class="head">

--- a/x15.4.html
+++ b/x15.4.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="split chapter"><head><meta charset="utf-8"><title>15.4 Array Objects # &#9417; &#9402; &#9312; &#9398; &#8212; Annotated ES5</title><link rel="stylesheet" href="style.css"><link rel="shortcut icon" href="favicon.ico"><link href="x15.3.html" title="15.3 Function Objects " rel="prev">
+<html class="split chapter"><head><meta charset="utf-8"><title>15.4 Array Objects # &#9417; &#9402; &#9312; &#9398; &#8212; Annotated ES5</title><link rel="stylesheet" href="style.css"><link href="x15.3.html" title="15.3 Function Objects " rel="prev">
   <link href="spec.html#contents" title="TOC" rel="index">
   <link href="x15.5.html" title="15.5 String Objects " rel="next">
   </head><body><div class="head">

--- a/x15.5.html
+++ b/x15.5.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="split chapter"><head><meta charset="utf-8"><title>15.5 String Objects # &#9417; &#9402; &#9312; &#9398; &#8212; Annotated ES5</title><link rel="stylesheet" href="style.css"><link rel="shortcut icon" href="favicon.ico"><link href="x15.4.html" title="15.4 Array Objects " rel="prev">
+<html class="split chapter"><head><meta charset="utf-8"><title>15.5 String Objects # &#9417; &#9402; &#9312; &#9398; &#8212; Annotated ES5</title><link rel="stylesheet" href="style.css"><link href="x15.4.html" title="15.4 Array Objects " rel="prev">
   <link href="spec.html#contents" title="TOC" rel="index">
   <link href="x15.6.html" title="15.6 Boolean Objects " rel="next">
   </head><body><div class="head">

--- a/x15.6.html
+++ b/x15.6.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="split chapter"><head><meta charset="utf-8"><title>15.6 Boolean Objects # &#9417; &#9402; &#9312; &#9398; &#8212; Annotated ES5</title><link rel="stylesheet" href="style.css"><link rel="shortcut icon" href="favicon.ico"><link href="x15.5.html" title="15.5 String Objects " rel="prev">
+<html class="split chapter"><head><meta charset="utf-8"><title>15.6 Boolean Objects # &#9417; &#9402; &#9312; &#9398; &#8212; Annotated ES5</title><link rel="stylesheet" href="style.css"><link href="x15.5.html" title="15.5 String Objects " rel="prev">
   <link href="spec.html#contents" title="TOC" rel="index">
   <link href="x15.7.html" title="15.7 Number Objects " rel="next">
   </head><body><div class="head">

--- a/x15.7.html
+++ b/x15.7.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="split chapter"><head><meta charset="utf-8"><title>15.7 Number Objects # &#9417; &#9402; &#9312; &#9398; &#8212; Annotated ES5</title><link rel="stylesheet" href="style.css"><link rel="shortcut icon" href="favicon.ico"><link href="x15.6.html" title="15.6 Boolean Objects " rel="prev">
+<html class="split chapter"><head><meta charset="utf-8"><title>15.7 Number Objects # &#9417; &#9402; &#9312; &#9398; &#8212; Annotated ES5</title><link rel="stylesheet" href="style.css"><link href="x15.6.html" title="15.6 Boolean Objects " rel="prev">
   <link href="spec.html#contents" title="TOC" rel="index">
   <link href="x15.8.html" title="15.8 The Math Object " rel="next">
   </head><body><div class="head">

--- a/x15.8.html
+++ b/x15.8.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="split chapter"><head><meta charset="utf-8"><title>15.8 The Math Object # &#9417; &#9402; &#9312; &#9398; &#8212; Annotated ES5</title><link rel="stylesheet" href="style.css"><link rel="shortcut icon" href="favicon.ico"><link href="x15.7.html" title="15.7 Number Objects " rel="prev">
+<html class="split chapter"><head><meta charset="utf-8"><title>15.8 The Math Object # &#9417; &#9402; &#9312; &#9398; &#8212; Annotated ES5</title><link rel="stylesheet" href="style.css"><link href="x15.7.html" title="15.7 Number Objects " rel="prev">
   <link href="spec.html#contents" title="TOC" rel="index">
   <link href="x15.9.html" title="15.9 Date Objects " rel="next">
   </head><body><div class="head">

--- a/x15.9.html
+++ b/x15.9.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="split chapter"><head><meta charset="utf-8"><title>15.9 Date Objects # &#9417; &#9402; &#9312; &#9398; &#8212; Annotated ES5</title><link rel="stylesheet" href="style.css"><link rel="shortcut icon" href="favicon.ico"><link href="x15.8.html" title="15.8 The Math Object " rel="prev">
+<html class="split chapter"><head><meta charset="utf-8"><title>15.9 Date Objects # &#9417; &#9402; &#9312; &#9398; &#8212; Annotated ES5</title><link rel="stylesheet" href="style.css"><link href="x15.8.html" title="15.8 The Math Object " rel="prev">
   <link href="spec.html#contents" title="TOC" rel="index">
   <link href="x15.10.html" title="15.10 RegExp (Regular Expression) Objects " rel="next">
   </head><body><div class="head">

--- a/x15.html
+++ b/x15.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="split chapter"><head><meta charset="utf-8"><title>15 Standard Built-in ECMAScript Objects # &#9417; &#9402; &#9312; &#9398; &#8212; Annotated ES5</title><link rel="stylesheet" href="style.css"><link rel="shortcut icon" href="favicon.ico"><link href="x14.html" title="14 Program " rel="prev">
+<html class="split chapter"><head><meta charset="utf-8"><title>15 Standard Built-in ECMAScript Objects # &#9417; &#9402; &#9312; &#9398; &#8212; Annotated ES5</title><link rel="stylesheet" href="style.css"><link href="x14.html" title="14 Program " rel="prev">
   <link href="spec.html#contents" title="TOC" rel="index">
   <link href="x15.1.html" title="15.1 The Global Object " rel="next">
   </head><body><div class="head">

--- a/x16.html
+++ b/x16.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="split chapter"><head><meta charset="utf-8"><title>16 Errors # &#9417; &#9402; &#9312; &#9398; &#8212; Annotated ES5</title><link rel="stylesheet" href="style.css"><link rel="shortcut icon" href="favicon.ico"><link href="x15.12.html" title="15.12 The JSON Object " rel="prev">
+<html class="split chapter"><head><meta charset="utf-8"><title>16 Errors # &#9417; &#9402; &#9312; &#9398; &#8212; Annotated ES5</title><link rel="stylesheet" href="style.css"><link href="x15.12.html" title="15.12 The JSON Object " rel="prev">
   <link href="spec.html#contents" title="TOC" rel="index">
   <link href="A.html" title="Annex A (informative) Grammar Summary " rel="next">
   </head><body><div class="head">

--- a/x2.html
+++ b/x2.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="split chapter"><head><meta charset="utf-8"><title>2 Conformance # &#9417; &#9402; &#9312; &#9398; &#8212; Annotated ES5</title><link rel="stylesheet" href="style.css"><link rel="shortcut icon" href="favicon.ico"><link href="x1.html" title="1 Scope " rel="prev">
+<html class="split chapter"><head><meta charset="utf-8"><title>2 Conformance # &#9417; &#9402; &#9312; &#9398; &#8212; Annotated ES5</title><link rel="stylesheet" href="style.css"><link href="x1.html" title="1 Scope " rel="prev">
   <link href="spec.html#contents" title="TOC" rel="index">
   <link href="x3.html" title="3 Normative references " rel="next">
   </head><body><div class="head">

--- a/x3.html
+++ b/x3.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="split chapter"><head><meta charset="utf-8"><title>3 Normative references # &#9417; &#9402; &#9312; &#9398; &#8212; Annotated ES5</title><link rel="stylesheet" href="style.css"><link rel="shortcut icon" href="favicon.ico"><link href="x2.html" title="2 Conformance " rel="prev">
+<html class="split chapter"><head><meta charset="utf-8"><title>3 Normative references # &#9417; &#9402; &#9312; &#9398; &#8212; Annotated ES5</title><link rel="stylesheet" href="style.css"><link href="x2.html" title="2 Conformance " rel="prev">
   <link href="spec.html#contents" title="TOC" rel="index">
   <link href="x4.html" title="4 Overview " rel="next">
   </head><body><div class="head">

--- a/x4.html
+++ b/x4.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="split chapter"><head><meta charset="utf-8"><title>4 Overview # &#9417; &#9402; &#9312; &#9398; &#8212; Annotated ES5</title><link rel="stylesheet" href="style.css"><link rel="shortcut icon" href="favicon.ico"><link href="x3.html" title="3 Normative references " rel="prev">
+<html class="split chapter"><head><meta charset="utf-8"><title>4 Overview # &#9417; &#9402; &#9312; &#9398; &#8212; Annotated ES5</title><link rel="stylesheet" href="style.css"><link href="x3.html" title="3 Normative references " rel="prev">
   <link href="spec.html#contents" title="TOC" rel="index">
   <link href="x5.html" title="5 Notational Conventions " rel="next">
   </head><body><div class="head">

--- a/x5.html
+++ b/x5.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="split chapter"><head><meta charset="utf-8"><title>5 Notational Conventions # &#9417; &#9402; &#9312; &#9398; &#8212; Annotated ES5</title><link rel="stylesheet" href="style.css"><link rel="shortcut icon" href="favicon.ico"><link href="x4.html" title="4 Overview " rel="prev">
+<html class="split chapter"><head><meta charset="utf-8"><title>5 Notational Conventions # &#9417; &#9402; &#9312; &#9398; &#8212; Annotated ES5</title><link rel="stylesheet" href="style.css"><link href="x4.html" title="4 Overview " rel="prev">
   <link href="spec.html#contents" title="TOC" rel="index">
   <link href="x6.html" title="6 Source Text " rel="next">
   </head><body><div class="head">

--- a/x6.html
+++ b/x6.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="split chapter"><head><meta charset="utf-8"><title>6 Source Text # &#9417; &#9402; &#9312; &#9398; &#8212; Annotated ES5</title><link rel="stylesheet" href="style.css"><link rel="shortcut icon" href="favicon.ico"><link href="x5.html" title="5 Notational Conventions " rel="prev">
+<html class="split chapter"><head><meta charset="utf-8"><title>6 Source Text # &#9417; &#9402; &#9312; &#9398; &#8212; Annotated ES5</title><link rel="stylesheet" href="style.css"><link href="x5.html" title="5 Notational Conventions " rel="prev">
   <link href="spec.html#contents" title="TOC" rel="index">
   <link href="x7.html" title="7 Lexical Conventions " rel="next">
   </head><body><div class="head">

--- a/x7.html
+++ b/x7.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="split chapter"><head><meta charset="utf-8"><title>7 Lexical Conventions # &#9417; &#9402; &#9312; &#9398; &#8212; Annotated ES5</title><link rel="stylesheet" href="style.css"><link rel="shortcut icon" href="favicon.ico"><link href="x6.html" title="6 Source Text " rel="prev">
+<html class="split chapter"><head><meta charset="utf-8"><title>7 Lexical Conventions # &#9417; &#9402; &#9312; &#9398; &#8212; Annotated ES5</title><link rel="stylesheet" href="style.css"><link href="x6.html" title="6 Source Text " rel="prev">
   <link href="spec.html#contents" title="TOC" rel="index">
   <link href="x8.html" title="8 Types " rel="next">
   </head><body><div class="head">

--- a/x8.html
+++ b/x8.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="split chapter"><head><meta charset="utf-8"><title>8 Types # &#9417; &#9402; &#9312; &#9398; &#8212; Annotated ES5</title><link rel="stylesheet" href="style.css"><link rel="shortcut icon" href="favicon.ico"><link href="x7.html" title="7 Lexical Conventions " rel="prev">
+<html class="split chapter"><head><meta charset="utf-8"><title>8 Types # &#9417; &#9402; &#9312; &#9398; &#8212; Annotated ES5</title><link rel="stylesheet" href="style.css"><link href="x7.html" title="7 Lexical Conventions " rel="prev">
   <link href="spec.html#contents" title="TOC" rel="index">
   <link href="x9.html" title="9 Type Conversion and Testing " rel="next">
   </head><body><div class="head">

--- a/x9.html
+++ b/x9.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="split chapter"><head><meta charset="utf-8"><title>9 Type Conversion and Testing # &#9417; &#9402; &#9312; &#9398; &#8212; Annotated ES5</title><link rel="stylesheet" href="style.css"><link rel="shortcut icon" href="favicon.ico"><link href="x8.html" title="8 Types " rel="prev">
+<html class="split chapter"><head><meta charset="utf-8"><title>9 Type Conversion and Testing # &#9417; &#9402; &#9312; &#9398; &#8212; Annotated ES5</title><link rel="stylesheet" href="style.css"><link href="x8.html" title="8 Types " rel="prev">
   <link href="spec.html#contents" title="TOC" rel="index">
   <link href="x10.html" title="10 Executable Code and Execution Contexts " rel="next">
   </head><body><div class="head">


### PR DESCRIPTION
Omit `<link rel="shortcut icon" href="/favicon.ico">` as it’s [implied](http://mathiasbynens.be/notes/rel-shortcut-icon) anyway.

Also, use uppercase DOCTYPE consistently.
