### PR TITLE
Add a link to ECMA TC39’s HTML version of the normative spec

### DIFF
--- a/A.html
+++ b/A.html
@@ -1292,7 +1292,7 @@
 	<p class="def1-btm">
 	<code><b>a
 	 b  c  d  e  f  g  h  i  j  k  l  m  n  o  p  q  r  s  t  u  v  w  x
-	 y  z<br>A  B  C  D  E  F  G  H  I  J  K  L  M  N  O  P  Q  R  S  T 
+	 y  z<br>A  B  C  D  E  F  G  H  I  J  K  L  M  N  O  P  Q  R  S  T
 	U  V  W  X  Y  Z</b></code></p>
 	<p class="keep">
 	<i>uriMark </i><b>:::</b>
@@ -1381,7 +1381,7 @@
 	<p class="def1-btm">
 	<code><b>a
 	 b  c  d  e  f  g  h  i  j  k  l  m  n  o  p  q  r  s  t  u  v  w  x
-	 y  z<br>A  B  C  D  E  F  G  H  I  J  K  L  M  N  O  P  Q  R  S  T 
+	 y  z<br>A  B  C  D  E  F  G  H  I  J  K  L  M  N  O  P  Q  R  S  T
 	U  V  W  X  Y  Z</b></code></p>
 	<p class="keep">
 	<i>IdentityEscape </i><b>::</b><i class="see">See <a href="x15.10.html#x15.10.1">15.10.1</a></i></p>

--- a/C.html
+++ b/C.html
@@ -64,7 +64,7 @@ within strict mode code.  (<a>7.6.12</a> [?]<!-- FIXME -->).</li>
 		of an Assignment operator (<a href="x11.html#x11.13">11.13</a>) or of a <i>PostfixExpression</i>
 		(<a href="x11.html#x11.3">11.3</a>) or as the <i>UnaryExpression</i>
 		operated upon by a Prefix Increment (<a href="x11.html#x11.4.4">11.4.4</a>) or a Prefix Decrement
-		(<a href="x11.html#x11.4.5">11.4.5</a>) operator. 
+		(<a href="x11.html#x11.4.5">11.4.5</a>) operator.
 		</p>
 		</li>
 		<li><p>

--- a/D.html
+++ b/D.html
@@ -25,7 +25,7 @@
 	invocations of standard built-in objects and methods has been
 	clarified by making it explicit that the intent is that the actual
 	built-in object is to be used rather than the current dynamic value
-	of the correspondingly named property. 
+	of the correspondingly named property.
 	</p>
 	<p>
 	<a href="x11.html#x11.8.2">11.8.2</a>,

--- a/E.html
+++ b/E.html
@@ -78,7 +78,7 @@
 	arguments object is <code><b>"Arguments"</b></code>.
 	 In Edition 3, it was <code><b>"Object"</b></code>.
 	This is observable if <code><b>toString</b></code>
-	is called as a method of an arguments object. 
+	is called as a method of an arguments object.
 	</p>
 	<p>
 	<a href="x12.html#x12.6.4">12.6.4</a>:
@@ -89,7 +89,7 @@
 	<p>
 	<a href="x15.html#x15">15</a>:
 	In Edition 5, the following new properties are defined on built-in
-	objects that exist in Edition 3: 
+	objects that exist in Edition 3:
 <code><b>Object.getPrototypeOf</b></code>,
 <code><b>Object.getOwnPropertyDescriptor</b></code>,
 <code><b>Object.getOwnPropertyNames</b></code>,
@@ -185,7 +185,7 @@
 	non-configurable and shadow any inherited properties with the same
 	names. In Edition 3, these properties did not exist and ECMAScript
 	code could dynamically add and remove writable properties with such
-	names and could access inherited properties with such names.  
+	names and could access inherited properties with such names.
 	</p>
 	<p>
 	<a href="x15.9.html#x15.9.4.2">15.9.4.2</a>:
@@ -216,7 +216,7 @@
 	<a href="x15.11.html#x15.11.2.1">15.11.2.1</a>,
 	<a href="x15.11.html#x15.11.4.3">15.11.4.3</a>:  In Edition 5, if an initial value for the <code><b>message</b></code>
 	property of an Error object is not specified via the <code><b>Error</b></code>
-	constructor the initial value of the property is the empty String. 
+	constructor the initial value of the property is the empty String.
 	In Edition 3, such an initial value is implementation defined.</p>
 	<p>
 	<a href="x15.11.html#x15.11.4.4">15.11.4.4</a>:

--- a/index.html
+++ b/index.html
@@ -24,8 +24,9 @@
 <p><b class="other">This is <i>not</i> the normative ECMAScript Language specification.</b>
 The normative spec
 (<a href="http://www.ecmascript.org/">ECMA 262</a>)
-is a PDF file maintained by ECMA TC39 and is available from 
-<a href="http://www.ecmascript.org/">http://www.ecmascript.org/</a></p>
+is a PDF file maintained by ECMA TC39 and is available from
+<a href="http://www.ecmascript.org/">http://www.ecmascript.org/</a>. An auto-generated
+HTML version is available, too: <a href="http://ecma-international.org/ecma-262/5.1/">http://ecma-international.org/ecma-262/5.1/</a></p>
 </div>
 
 <p>This is an <b>annotated, hyperlinked, HTML version</b> of Edition 5.1 of
@@ -1159,7 +1160,7 @@ the ECMAScript Specification,
 	develop a fourth edition of ECMAScript. Although that work was not
 	completed and not published
 	<a class="footnote" id="sdfootnote1anc" href="#sdfootnote1sym">[1]</a>
-	
+
 	as the fourth edition of ECMAScript, it informs continuing evolution
 	of the language. The present fifth edition of ECMAScript (published
 	as ECMA-262 5<sup>th</sup>
@@ -1481,7 +1482,7 @@ an object is a member of the remaining built-in type
 	A complete ECMAScript program may be composed for both strict mode
 	and non-strict mode ECMAScript code units. In this case, strict mode
 	only applies when actually executing code that is defined within a
-	<a href="#x10.1.1" class="term-ref">strict mode code</a> unit. 
+	<a href="#x10.1.1" class="term-ref">strict mode code</a> unit.
 	</p>
 	<p>
 	In
@@ -1572,7 +1573,7 @@ an object is a member of the remaining built-in type
 	<h4 id="x4.3.10">4.3.10<br><dfn id="Undefined_type">Undefined type</dfn> <a href="#x4.3.10">#</a> <a href="#x4.3.10-toc" class="bak">Ⓣ</a> <b class="erra">Ⓔ</b> <b class="rev1">①</b> <b class="anno">Ⓐ</b></h4>
 	<p>
 	type
-	whose sole value is the undefined value. 
+	whose sole value is the undefined value.
 	</p>
 	<h4 id="x4.3.11">4.3.11<br><dfn id="null_value">null value</dfn> <a href="#x4.3.11">#</a> <a href="#x4.3.11-toc" class="bak">Ⓣ</a> <b class="erra">Ⓔ</b> <b class="rev1">①</b> <b class="anno">Ⓐ</b></h4>
 	<p>
@@ -1606,7 +1607,7 @@ an object is a member of the remaining built-in type
 	<h4 id="x4.3.16">4.3.16<br><dfn id="String_value">String value</dfn> <a href="#x4.3.16">#</a> <a href="#x4.3.16-toc" class="bak">Ⓣ</a> <b class="erra">Ⓔ</b> <b class="rev1">①</b> <b class="anno">Ⓐ</b></h4>
 	<p>
 	<a href="#primitive_value" class="term-ref">primitive value</a> that is a finite ordered sequence of zero or more 16-bit
-	unsigned integer. 
+	unsigned integer.
 	</p>
 	<p><b class="note">NOTE</b> A
 	String value is a member of the String type. Each integer value in
@@ -1683,7 +1684,7 @@ an object is a member of the remaining built-in type
 	and <code><b><a href="#x15.8.2.8">Math.exp</a></b></code>. An
 	implementation may provide implementation-dependent built-in
 	functions that are not described in this specification.
-	
+
 	</p>
 	<h4 id="x4.3.26">4.3.26<br><dfn id="property">property</dfn> <a href="#x4.3.26">#</a> <a href="#x4.3.26-toc" class="bak">Ⓣ</a> <b class="erra">Ⓔ</b> <b class="rev1">①</b> <b class="anno">Ⓐ</b></h4>
 	<p>
@@ -1707,7 +1708,7 @@ an object is a member of the remaining built-in type
 	<p><b class="note">NOTE</b> Standard
 	built-in methods are defined in this specification, and an
 	ECMAScript implementation may specify and provide other additional
-	built-in methods. 
+	built-in methods.
 	</p>
 	<h4 id="x4.3.29">4.3.29<br><dfn id="attribute">attribute</dfn> <a href="#x4.3.29">#</a> <a href="#x4.3.29-toc" class="bak">Ⓣ</a> <b class="erra">Ⓔ</b> <b class="rev1">①</b> <b class="anno">Ⓐ</b></h4>
 	<p>
@@ -1746,7 +1747,7 @@ an object is a member of the remaining built-in type
 	<p>
 	A
 	<i>lexical grammar</i> for ECMAScript is given in <a href="#x7">clause 7</a>. This
-	grammar has as its terminal symbols characters (Unicode code units) 
+	grammar has as its terminal symbols characters (Unicode code units)
 	that conform to the rules for <i>SourceCharacter</i>
 	defined in <a href="#x6">Clause 6</a>. It defines a set of productions, starting from
 	the goal symbol <i>InputElementDiv</i>
@@ -2166,7 +2167,7 @@ an object is a member of the remaining built-in type
 	algorithm should terminate. The notation Result(<i>n</i>)
 	is used as shorthand for “the result
 	of step <i>n</i>”.
-	
+
 	</p>
 	<p>
 	For
@@ -2175,7 +2176,7 @@ an object is a member of the remaining built-in type
 	further divided into indented substeps.  Outline numbering
 	conventions are used to identify substeps with the first level of
 	substeps labelled with lower case alphabetic characters and the
-	second level of substeps labelled with lower case roman numerals. 
+	second level of substeps labelled with lower case roman numerals.
 	If more than three levels are required these rules repeat with the
 	fourth level using numeric labels. For example:</p>
 	<ol>
@@ -2188,7 +2189,7 @@ an object is a member of the remaining built-in type
 			</li>
 			<li><p>
 			Substep
-			
+
 			</p>
 			<ol>
 				<li><p>
@@ -2420,7 +2421,7 @@ an object is a member of the remaining built-in type
 	distinctions when forming words or phrases in certain languages. In
 	ECMAScript source text, &lt;ZWNJ&gt;
 	and &lt;ZWJ&gt;
-	may also be used in an identifier after the first character. 
+	may also be used in an identifier after the first character.
 	</p>
 	<p>
 	&lt;BOM&gt;
@@ -2430,7 +2431,7 @@ an object is a member of the remaining built-in type
 	characters intended for this purpose can sometimes also appear after
 	the start of a text, for example as a result of concatenating files.
 	&lt;BOM&gt; characters are treated as white space characters (see
-	<a href="#x7.2">7.2</a>). 
+	<a href="#x7.2">7.2</a>).
 	</p>
 	<p class="sm-btm">
 	The
@@ -2694,13 +2695,13 @@ an object is a member of the remaining built-in type
 	cannot occur within any token except a <i><a href="#x7.8.4">StringLiteral</a></i>.
 	Line terminators may only occur within a <i><a href="#x7.8.4">StringLiteral</a></i>
 	token as part of a <i>LineContinuation</i>.
-	
+
 	</p>
 	<p>
 	A
 	line terminator can occur within a <i>MultiLineComment</i>
 	(<a href="#x7.4">7.4</a>) but cannot occur within a <i>SingleLineComment</i>.
-	
+
 	</p>
 	<p>
 	Line
@@ -2755,7 +2756,7 @@ an object is a member of the remaining built-in type
 				<td width="152">
 					<p>
 					Carriage
-					Return 
+					Return
 					</p>
 				</td>
 				<td width="147">
@@ -4480,8 +4481,8 @@ the empty character sequence.</P></LI>
 				the third <i>HexDigit</i>)
 				plus the MV of the fourth <i>HexDigit</i>.</p>
 			</li></ul>
-		
-	
+
+
 	<p>
 	A
 	conforming implementation, when processing <a href="#x10.1.1" class="term-ref">strict mode code</a> (see
@@ -5125,14 +5126,14 @@ and
 		<i>named accessor property</i> associates a name with one or two
 		accessor functions, and a set of Boolean attributes. The accessor
 		functions are used to store or retrieve an ECMAScript language
-		value that is associated with the property. 
+		value that is associated with the property.
 		</p>
 		</li>
 		<li><p>
 		An
 		<i>internal property</i> has no name and is not directly accessible
 		via ECMAScript language operators. Internal properties exist purely
-		for specification purposes. 
+		for specification purposes.
 		</p>
 	</li></ul>
 	<p>
@@ -5173,7 +5174,7 @@ and
 				<td width="115" height="8">
 					<p>
 					[[Value]]
-					
+
 					</p>
 				</td>
 				<td width="134">
@@ -5192,7 +5193,7 @@ and
 				<td width="115" height="17">
 					<p>
 					[[Writable]]
-					
+
 					</p>
 				</td>
 				<td width="134">
@@ -5844,7 +5845,7 @@ and
 	[[DefineOwnProperty]] internal method of a host object must not
 	permit the addition of a new property to a host object if the
 	[[Extensible]] internal property of that host object has been
-	observed by ECMAScript code to be <b>false</b>. 
+	observed by ECMAScript code to be <b>false</b>.
 	</p>
 	<p>
 	If
@@ -6470,7 +6471,7 @@ and
 	<dfn id="property-identifier">Property Identifier</dfn> type is used to associate a property name with a
 	Property Descriptor.  Values of the Property Identifier type are
 	pairs of the form (name, descriptor), where name is a String and
-	descriptor is a Property Descriptor value. 
+	descriptor is a Property Descriptor value.
 	</p>
 	<p>
 	The
@@ -7199,7 +7200,7 @@ and
 		</li>
 		<li><p>
 		If
-		<a href="#x9.11">IsCallable</a>(<i>valueOf)</i> is <b>true</b> then, 
+		<a href="#x9.11">IsCallable</a>(<i>valueOf)</i> is <b>true</b> then,
 		</p>
 		<ol>
 			<li><p>
@@ -7388,7 +7389,7 @@ and
 		<ol>
 			<li><p>
 			<a href="#reject-DefineOwnProperty">Reject</a>,
-			if the [[Configurable]] field of <i>current</i> is <b>false</b>. 
+			if the [[Configurable]] field of <i>current</i> is <b>false</b>.
 			</p>
 			</li>
 			<li><p>
@@ -7439,7 +7440,7 @@ and
 					<a href="#reject-DefineOwnProperty">Reject</a>,
 					if the [[Value]] field of <i>Desc</i> is present and
 					<a href="#x9.12">SameValue</a>(<i>Desc</i>.[[Value]], <i>current</i>.[[Value]]) is
-					<b>false</b>. 
+					<b>false</b>.
 					</p>
 				</li></ol>
 			</li></ol>
@@ -7670,7 +7671,7 @@ and
 					<p>
 					The
 					result is <b>false</b> if the argument is <b>+0</b>, <span class="symbol"><b>−</b></span><b>0</b>,
-					or <b>NaN</b>; otherwise the result is <b>true</b>. 
+					or <b>NaN</b>; otherwise the result is <b>true</b>.
 					</p>
 				</td>
 			</tr>
@@ -9023,7 +9024,7 @@ and
 	 <a href="#eval-code">Eval code</a> is strict eval code if it begins with a Directive Prologue
 		that contains a Use Strict Directive or if the call to eval is a
 		direct call (see <a href="#x15.1.2.1.1">15.1.2.1.1</a>) to the <a href="#x15.1.2.1">eval function</a> that is contained
-		in <a href="#x10.1.1" class="term-ref">strict mode code</a>. 
+		in <a href="#x10.1.1" class="term-ref">strict mode code</a>.
 		</p>
 		</li>
 		<li><p>
@@ -9069,7 +9070,7 @@ and
 	Lexical Environment values. The outer reference of a (inner) Lexical
 	Environment is a reference to the Lexical Environment that logically
 	surrounds the inner Lexical Environment. An outer Lexical
-	Environment may, of course, have its own outer Lexical Environment. 
+	Environment may, of course, have its own outer Lexical Environment.
 	A Lexical Environment may serve as the outer environment for
 	multiple inner Lexical Environments. For example, if a
 	<i><a href="#x13">FunctionDeclaration</a></i>
@@ -9108,7 +9109,7 @@ and
  and object environment record. The
 	abstract class includes the abstract specification methods defined
 	in Table 17. These abstract methods have distinct concrete
-	algorithms for each of the concrete subclasses. 
+	algorithms for each of the concrete subclasses.
 	</p>
 	<center>
 		<table width="690" border="1" bordercolor="#000000" cellpadding="8" cellspacing="0" rules="ROWS">
@@ -9152,7 +9153,7 @@ and
 					a new mutable binding in an environment record. The String value
 					<i>N</i> is the text
 					of the bound name. If the optional Boolean argument <i>D</i>
-					is <b>true</b> the binding is may be subsequently deleted.  
+					is <b>true</b> the binding is may be subsequently deleted.
 					</p>
 				</td>
 			</tr>
@@ -9190,7 +9191,7 @@ and
 					is used to identify strict mode references. If <i>S</i>
 					is <b>true</b> and
 					the binding does not exist or is uninitialized throw a
-					<b><a href="#x15.11.6.3" class="term-ref">ReferenceError</a></b> exception. 
+					<b><a href="#x15.11.6.3" class="term-ref">ReferenceError</a></b> exception.
 					</p>
 				</td>
 			</tr>
@@ -9217,7 +9218,7 @@ and
 					<p>Returns
 					the value to use as the <b>this</b> value on calls to function
 					objects that are obtained as binding values from this
-					environment record. 
+					environment record.
 					</p>
 				</td>
 			</tr>
@@ -9278,7 +9279,7 @@ and
 					the value of an already existing but uninitialized <a href="#immutable-binding">immutable binding</a> in an environment record. The String value <i>N</i>
 					is the text of the bound name. <i>V</i>
 					is the value for the binding and is a value of any ECMAScript
-					<a href="#language-type">language type</a>. 
+					<a href="#language-type">language type</a>.
 					</p>
 				</td>
 			</tr>
@@ -9351,7 +9352,7 @@ and
 	must already exist. If the binding is an <a href="#immutable-binding">immutable binding</a>, a
 	<b>TypeError</b> is
 	thrown
-	if <i>S</i> is <b>true</b>. 
+	if <i>S</i> is <b>true</b>.
 	</p>
 
 	<ol>
@@ -9485,7 +9486,7 @@ and
 	argument <i>N</i> to the
 	value of argument <i>V</i>.
 	An uninitialized <a href="#immutable-binding">immutable binding</a> for <i>N</i>
-	must already exist. 
+	must already exist.
 	</p>
 	<ol>
 		<li><p>
@@ -9836,7 +9837,7 @@ and
 	As
 	ECMAScript code is executed, additional properties may be added to
 	the <a href="#x15.1" class="term-ref">global object</a> and the initial properties may be modified.
-	
+
 	</p>
 	<h3 id="x10.3">10.3 Execution Contexts <a href="#x10.3">#</a> <a href="#x10.3-toc" class="bak">Ⓣ</a> <b class="erra">Ⓔ</b> <b class="rev1">①</b> <b class="anno">Ⓐ</b></h3>
 	<p>
@@ -9931,7 +9932,7 @@ and
 	execution context is purely a specification mechanism and need not
 	correspond to any particular artefact of an ECMAScript
 	implementation.  It is impossible for an ECMAScript program to
-	access an execution context. 
+	access an execution context.
 	</p>
 	<h4 id="x10.3.1">10.3.1 Identifier Resolution <a href="#x10.3.1">#</a> <a href="#x10.3.1-toc" class="bak">Ⓣ</a> <b class="erra">Ⓔ</b> <b class="rev1">①</b> <b class="anno">Ⓐ</b></h4>
 	<p>
@@ -10110,7 +10111,7 @@ and
 		</li>
 		<li><p>
 		Let
-		<i>localEnv</i> be the result of calling <a href="#x10.2.2.2">NewDeclarativeEnvironment</a> 
+		<i>localEnv</i> be the result of calling <a href="#x10.2.2.2">NewDeclarativeEnvironment</a>
 		passing the value of the [[Scope]] internal property of <i>F</i> as
 		the argument.</p>
 		</li>
@@ -10171,7 +10172,7 @@ and
 			Let
 			<i>func </i>be the function whose [[Call]] internal method
 			initiated execution of <i>code</i>. Let <i>names</i> be the value
-			of <i>func</i>’s [[FormalParameters]] internal property.  
+			of <i>func</i>’s [[FormalParameters]] internal property.
 			</p>
 			</li>
 			<li><p>
@@ -10301,7 +10302,7 @@ and
 			</li>
 			<li><p>
 			If
-			<i>strict</i> is <b>true</b>, then 
+			<i>strict</i> is <b>true</b>, then
 			</p>
 			<ol>
 				<li><p>
@@ -10438,7 +10439,7 @@ and
 		</li>
 		<li><p>
 		Repeat
-		while <i>indx</i> &gt;= 0, 
+		while <i>indx</i> &gt;= 0,
 		</p>
 		<ol>
 			<li><p>
@@ -10638,7 +10639,7 @@ and
 		</li>
 		<li><p>
 		Else,
-		<i>map</i> contains a formal parameter mapping for <i>P</i> so, 
+		<i>map</i> contains a formal parameter mapping for <i>P</i> so,
 		</p>
 		<ol>
 			<li><p>
@@ -10686,7 +10687,7 @@ and
 		</li>
 		<li><p>
 		Return
-		<i>desc</i>. 
+		<i>desc</i>.
 		</p>
 	</li></ol>
 	<p>
@@ -11085,7 +11086,7 @@ and
 		<i>preceding</i>+1.</p>
 	</li></ol>
 	<p class="sp">
-	</p><p><b class="note">NOTE</b> 
+	</p><p><b class="note">NOTE</b>
 	[[DefineOwnProperty]] is used to ensure that own properties are
 	defined for the array even if the standard built-in Array prototype
 	object has been modified in a manner that would preclude the
@@ -12572,7 +12573,7 @@ IEEE 754 round-to-nearest mode.
 		</li>
 		<li><p>
 		If
-		<a href="#Type">Type</a>(<i>lprim</i>) is String or <a href="#Type">Type</a>(<i>rprim</i>) is String, then 
+		<a href="#Type">Type</a>(<i>lprim</i>) is String or <a href="#Type">Type</a>(<i>rprim</i>) is String, then
 		</p>
 		<ol>
 			<li><p>
@@ -13079,7 +13080,7 @@ IEEE 754 round-to-nearest mode.
 		<li><p>
 		If
 		it is not the case that both <a href="#Type">Type</a>(<i>px</i>) is String and <a href="#Type">Type</a>(<i>py</i>)
-		is String, then 
+		is String, then
 		</p>
 		<ol>
 			<li><p>
@@ -15381,7 +15382,7 @@ IEEE 754 round-to-nearest mode.
 				<li><p>
 				If<i>C</i>
 				has a <i>StatementList</i>,
-				then 
+				then
 				</p>
 				<ol>
 					<li><p>
@@ -15415,7 +15416,7 @@ IEEE 754 round-to-nearest mode.
 			<li><p>
 			If<i>C</i>
 			has a <i>StatementList</i>,
-			then 
+			then
 			</p>
 			<ol>
 				<li><p>
@@ -15536,7 +15537,7 @@ IEEE 754 round-to-nearest mode.
 		If
 		<i>found</i>
 		is <b>false</b>,
-		then 
+		then
 		</p>
 		<ol>
 			<li><p class="sm-btm">
@@ -15551,7 +15552,7 @@ IEEE 754 round-to-nearest mode.
 				<i>C</i>
 				be the next <i>CaseClause</i>
 				in <i>B</i>.
-				
+
 				</p>
 				</li>
 				<li><p class="sm-btm">
@@ -15655,7 +15656,7 @@ IEEE 754 round-to-nearest mode.
 			<li><p class="sm-btm">
 			If
 			<i>C</i>
-			has a StatementList, then 
+			has a StatementList, then
 			</p>
 			<ol>
 				<li><p class="sm-btm">
@@ -15912,7 +15913,7 @@ IEEE 754 round-to-nearest mode.
 		<li><p>
 		Let
 		<i>catchEnv</i> be the result of calling <a href="#x10.2.2.2">NewDeclarativeEnvironment</a>
-		passing <i>oldEnv</i> as the argument. 
+		passing <i>oldEnv</i> as the argument.
 		</p>
 		</li>
 		<li><p>
@@ -15994,7 +15995,7 @@ IEEE 754 round-to-nearest mode.
 			</li>
 			<li><p>
 			Let
-			<i>result</i> be an implementation defined <a href="#x8.9">Completion</a> value. 
+			<i>result</i> be an implementation defined <a href="#x8.9">Completion</a> value.
 			</p>
 		</li></ol>
 		</li>
@@ -16276,7 +16277,7 @@ IEEE 754 round-to-nearest mode.
 		[[Enumerable]]: <b>false</b>,
 		[[Configurable]]: <b>false</b>},
 		and <b>false</b>.
-		
+
 		</p>
 		</li>
 		<li><p>
@@ -16506,7 +16507,7 @@ IEEE 754 round-to-nearest mode.
 		[[Enumerable]]: <b>false</b>,
 		[[Configurable]]: <b>false</b>},
 		and <b>false</b>.
-		
+
 		</p>
 		</li>
 		<li><p>
@@ -16558,7 +16559,7 @@ IEEE 754 round-to-nearest mode.
 		<li><p>
 		Let
 		<i>progCxt</i> be a new execution context for <a href="#global-code">global code</a> as
-		described in <a href="#x10.4.1">10.4.1</a>. 
+		described in <a href="#x10.4.1">10.4.1</a>.
 		</p>
 		</li>
 		<li><p>
@@ -16604,7 +16605,7 @@ IEEE 754 round-to-nearest mode.
 		</li>
 		<li><p>
 		Return
-		(tailResult.type, V, tailResult.target) 
+		(tailResult.type, V, tailResult.target)
 		</p>
 	</li></ol>
 	<p>
@@ -16739,7 +16740,7 @@ IEEE 754 round-to-nearest mode.
 	behaviour corresponds to the invocation of the constructor’s
 	[[Call]] internal method and the “called as part of a new
 	expression” behaviour corresponds to the invocation of the
-	constructor’s [[Construct]] internal method. 
+	constructor’s [[Construct]] internal method.
 	</p>
 	<p>
 	Every
@@ -16769,7 +16770,7 @@ IEEE 754 round-to-nearest mode.
 	<p>
 	The
 	unique <i><a href="#x15.1" class="term-ref">global object</a></i> is created before control enters any
-	execution context. 
+	execution context.
 	</p>
 	<p>
 	Unless
@@ -17185,7 +17186,7 @@ If <i>inputString</i> does not contain any such characters, let
 	<p class="def1-btm">
 	<code><b>a
 	 b  c  d  e  f  g  h  i  j  k  l  m  n  o  p  q  r  s  t  u  v  w  x
-	 y  z<br>A  B  C  D  E  F  G  H  I  J  K  L  M  N  O  P  Q  R  S  T 
+	 y  z<br>A  B  C  D  E  F  G  H  I  J  K  L  M  N  O  P  Q  R  S  T
 	U  V  W  X  Y  Z</b></code></p>
 	<p class="keep">
 	<i>uriMark </i><b>:::</b> <b>one
@@ -17272,7 +17273,7 @@ If <i>inputString</i> does not contain any such characters, let
 				</li>
 				<li><p>
 				Else,
-				
+
 				</p>
 				<ol>
 					<li><p>
@@ -18106,7 +18107,7 @@ If <i>inputString</i> does not contain any such characters, let
 		<li><p>
 		Asset:
 		The argument <i>value</i> was not supplied or its type was Null or
-		Undefined. 
+		Undefined.
 		</p>
 		</li>
 		<li><p>
@@ -18586,7 +18587,7 @@ with arguments <i>obj </i>and <i>Properties</i>.</p>
 		<li><p>
 		For
 		each own enumerable property of <i>O</i> whose name String is <i>P</i>
-		
+
 		</p>
 		<ol>
 			<li><p>
@@ -18689,7 +18690,7 @@ with arguments <i>obj </i>and <i>Properties</i>.</p>
 	<h5 id="x15.2.4.4">15.2.4.4 Object.prototype.valueOf ( ) <a href="#x15.2.4.4">#</a> <a href="#x15.2.4.4-toc" class="bak">Ⓣ</a> <b class="erra">Ⓔ</b> <b class="rev1">①</b> <b class="anno">Ⓐ</b></h5>
 	<p>
 	When
-	the <b>valueOf</b> method is called, the following steps are taken: 
+	the <b>valueOf</b> method is called, the following steps are taken:
 	</p>
 	<ol>
 		<li><p>
@@ -18953,7 +18954,7 @@ with arguments <i>obj </i>and <i>Properties</i>.</p>
 		<li><p>
 		If
 		<i>strict</i> is <b>true</b>, throw any exceptions specified in
-		<a href="#x13.1">13.1</a> that apply. 
+		<a href="#x13.1">13.1</a> that apply.
 		</p>
 		</li>
 		<li><p>
@@ -19061,7 +19062,7 @@ with arguments <i>obj </i>and <i>Properties</i>.</p>
 	is called on an object <i>func</i>
 	with arguments <i>thisArg</i>
 	and <i>argArray</i>, the
-	following steps are taken: 
+	following steps are taken:
 	</p>
 	<ol>
 		<li><p>
@@ -19269,7 +19270,7 @@ with arguments <i>obj </i>and <i>Properties</i>.</p>
 			<li><p>
 			Set
 			the <b>length </b>own property of <i>F </i>to either 0 or
-			<i>L</i>, whichever is larger. 
+			<i>L</i>, whichever is larger.
 			</p>
 		</li></ol>
 		</li>
@@ -19432,7 +19433,7 @@ with arguments <i>obj </i>and <i>Properties</i>.</p>
 	“arguments” that throw a <b><a href="#x15.11.6.5" class="term-ref">TypeError</a></b> exception. An
 	ECMAScript implementation must not associate any implementation
 	specific behaviour  with accesses of these properties from strict
-	mode <a href="#function-code">function code</a>. 
+	mode <a href="#function-code">function code</a>.
 	</p>
 	<h5 id="x15.3.5.1">15.3.5.1 length <a href="#x15.3.5.1">#</a> <a href="#x15.3.5.1-toc" class="bak">Ⓣ</a> <b class="erra">Ⓔ</b> <b class="rev1">①</b> <b class="anno">Ⓐ</b></h5>
 	<p>
@@ -19530,7 +19531,7 @@ with arguments <i>obj </i>and <i>Properties</i>.</p>
 		If
 		<i>P</i> is <code><b>"caller"
 		</b></code>and <i>v</i> is a strict mode Function object, throw a
-		<b><a href="#x15.11.6.5" class="term-ref">TypeError</a></b> exception. 
+		<b><a href="#x15.11.6.5" class="term-ref">TypeError</a></b> exception.
 		</p>
 		</li>
 		<li><p>
@@ -19850,7 +19851,7 @@ with arguments <i>obj </i>and <i>Properties</i>.</p>
 		</li>
 		<li><p>
 		Else
-		
+
 		</p>
 		<ol>
 			<li><p>
@@ -19871,7 +19872,7 @@ with arguments <i>obj </i>and <i>Properties</i>.</p>
 			Let
 			<i>R</i> be the result of calling the [[Call]] internal method of
 			<i>func</i> providing <i>elementObj</i> as the <b>this</b> value
-			and an empty arguments list. 
+			and an empty arguments list.
 			</p>
 		</li></ol>
 		</li>
@@ -19904,7 +19905,7 @@ with arguments <i>obj </i>and <i>Properties</i>.</p>
 			</li>
 			<li><p>
 			Else
-			
+
 			</p>
 			<ol>
 				<li><p>
@@ -19925,7 +19926,7 @@ with arguments <i>obj </i>and <i>Properties</i>.</p>
 				Let
 				<i>R</i> be the result of calling the [[Call]] internal method of
 				<i>func</i> providing <i>elementObj</i> as the <b>this</b> value
-				and an empty arguments list. 
+				and an empty arguments list.
 				</p>
 			</li></ol>
 			</li>
@@ -20204,7 +20205,7 @@ with arguments <i>obj </i>and <i>Properties</i>.</p>
 		</li>
 		<li><p>
 		If
-		<i>len</i> is zero, 
+		<i>len</i> is zero,
 		</p>
 		<ol>
 			<li><p>
@@ -21155,7 +21156,7 @@ with arguments <i>obj </i>and <i>Properties</i>.</p>
 			</li>
 			<li><p>
 			Repeat,
-			while <i>k</i> &gt; (<i>len</i> –<i> actualDeleteCount</i> +<i>itemCount</i>) 
+			while <i>k</i> &gt; (<i>len</i> –<i> actualDeleteCount</i> +<i>itemCount</i>)
 			</p>
 			<ol>
 				<li><p>
@@ -21306,7 +21307,7 @@ with arguments <i>obj </i>and <i>Properties</i>.</p>
 		</li>
 		<li><p>
 		Repeat,
-		while <i>k</i> &gt; 0, 
+		while <i>k</i> &gt; 0,
 		</p>
 		<ol>
 			<li><p>
@@ -21453,7 +21454,7 @@ with arguments <i>obj </i>and <i>Properties</i>.</p>
 		</li>
 		<li><p>
 		If
-		<i>n </i>≥ 0, then 
+		<i>n </i>≥ 0, then
 		</p>
 		<ol>
 			<li><p>
@@ -21659,7 +21660,7 @@ with arguments <i>obj </i>and <i>Properties</i>.</p>
 	<code><b>every</b></code>
 	does not directly mutate the object on which it is called but the
 	object may be mutated by the calls to <i>callbackfn</i>.
-	
+
 	</p>
 	<p>
 	The
@@ -21908,13 +21909,13 @@ with arguments <i>obj </i>and <i>Properties</i>.</p>
 	<p>
 	<i>callbackfn</i>
 	is called with three arguments: the value of the element, the index
-	of the element, and the object being traversed. 
+	of the element, and the object being traversed.
 	</p>
 	<p>
 	<code><b>forEach</b></code>
 	does not directly mutate the object on which it is called but the
 	object may be mutated by the calls to <i>callbackfn</i>.
-	
+
 	</p>
 	<p>
 	The
@@ -22045,7 +22046,7 @@ with arguments <i>obj </i>and <i>Properties</i>.</p>
 	<p>
 	When
 	the <code><b>map</b></code> method is
-	called with one or two arguments, the following steps are taken: 
+	called with one or two arguments, the following steps are taken:
 	</p>
 	<ol>
 		<li><p>
@@ -22181,7 +22182,7 @@ with arguments <i>obj </i>and <i>Properties</i>.</p>
 	<p>
 	When
 	the <code><b>filter</b></code> method
-	is called with one or two arguments, the following steps are taken: 
+	is called with one or two arguments, the following steps are taken:
 	</p>
 	<ol>
 		<li><p>
@@ -22325,7 +22326,7 @@ with arguments <i>obj </i>and <i>Properties</i>.</p>
 	<p>
 	When
 	the <code><b>reduce</b></code> method
-	is called with one or two arguments, the following steps are taken: 
+	is called with one or two arguments, the following steps are taken:
 	</p>
 	<ol>
 		<li><p>
@@ -22498,7 +22499,7 @@ with arguments <i>obj </i>and <i>Properties</i>.</p>
 	<p>
 	When
 	the <code><b>reduceRight </b></code>method
-	is called with one or two arguments, the following steps are taken: 
+	is called with one or two arguments, the following steps are taken:
 	</p>
 	<ol>
 		<li><p>
@@ -22787,7 +22788,7 @@ with arguments <i>obj </i>and <i>Properties</i>.</p>
 					Call
 					the default [[DefineOwnProperty]] internal method (<a href="#x8.12.9">8.12.9</a>) on <i>A</i>
 					passing <b>"</b><code><b>length</b></code><b>"</b>,
-					<i>newLenDesc</i>, and <b>false</b> as arguments. 
+					<i>newLenDesc</i>, and <b>false</b> as arguments.
 					</p>
 					</li>
 					<li><p>
@@ -24365,7 +24366,7 @@ with arguments <i>obj </i>and <i>Properties</i>.</p>
 	by this String object. The array index named properties correspond
 	to the individual characters of the String value. A special
 	[[GetOwnProperty]] internal method is used to specify the number,
-	values, and attributes of the array index named properties. 
+	values, and attributes of the array index named properties.
 	</p>
 	<h5 id="x15.5.5.1">15.5.5.1 length <a href="#x15.5.5.1">#</a> <a href="#x15.5.5.1-toc" class="bak">Ⓣ</a> <b class="erra">Ⓔ</b> <b class="rev1">①</b> <b class="anno">Ⓐ</b></h5>
 	<p>
@@ -24402,7 +24403,7 @@ with arguments <i>obj </i>and <i>Properties</i>.</p>
 		</li>
 		<li><p>
 		If
-		<i>desc</i> is not <b>undefined </b>return <i>desc</i>. 
+		<i>desc</i> is not <b>undefined </b>return <i>desc</i>.
 		</p>
 		</li>
 
@@ -24915,7 +24916,7 @@ with arguments <i>obj </i>and <i>Properties</i>.</p>
 	may be more precise than <code><b>toString</b></code>
 	for some values because toString only prints enough significant
 	digits to distinguish the number from adjacent number values. For
-	example, 
+	example,
 	</p>
 	<p class="sp">(<code><b>1000000000000000128).toString()</b></code>
 	returns <code><b>"1000000000000000100"</b></code>,<br>while
@@ -24969,7 +24970,7 @@ with arguments <i>obj </i>and <i>Properties</i>.</p>
 			<li><p>
 			Return
 			the concatenation of the Strings <i>s</i> and <code><b>"Infinity"</b></code>.
-			
+
 			</p>
 		</li></ol>
 		</li>
@@ -25017,7 +25018,7 @@ with arguments <i>obj </i>and <i>Properties</i>.</p>
 			</li>
 			<li><p>
 			Else,
-			<i>fractionDigits</i> is <b>undefined</b> 
+			<i>fractionDigits</i> is <b>undefined</b>
 			</p>
 			<ol>
 				<li><p>
@@ -25055,7 +25056,7 @@ with arguments <i>obj </i>and <i>Properties</i>.</p>
 		</li>
 		<li><p>
 		If
-		<i>e</i> = 0, then 
+		<i>e</i> = 0, then
 		</p>
 		<ol>
 			<li><p>
@@ -25270,7 +25271,7 @@ with arguments <i>obj </i>and <i>Properties</i>.</p>
 				<ol>
 					<li><p>
 					If
-					<i>e</i> &gt; 0,  then 
+					<i>e</i> &gt; 0,  then
 					</p>
 					<ol>
 						<li><p>
@@ -25507,7 +25508,7 @@ with arguments <i>obj </i>and <i>Properties</i>.</p>
 	arithmetic contained in <code><b>fdlibm</b></code>,
 	the freely distributable mathematical library from Sun Microsystems
 	(<a href="http://www.netlib.org/fdlibm">http://www.netlib.org/fdlibm</a>).
-	
+
 	</p>
 	<h5 id="x15.8.2.1">15.8.2.1 abs (x) <a href="#x15.8.2.1">#</a> <a href="#x15.8.2.1-toc" class="bak">Ⓣ</a> <b class="erra">Ⓔ</b> <b class="rev1">①</b> <b class="anno">Ⓐ</b></h5>
 	<p>
@@ -25654,7 +25655,7 @@ with arguments <i>obj </i>and <i>Properties</i>.</p>
 		If
 		<i>y</i>&gt;0
 		and <i>x</i>
-		is +0, the result is an implementation-dependent approximation to 
+		is +0, the result is an implementation-dependent approximation to
 		+<span class="symbol">π</span>/2.</p>
 		</li>
 		<li><p>
@@ -25722,7 +25723,7 @@ with arguments <i>obj </i>and <i>Properties</i>.</p>
 		If
 		<i>y</i>&lt;0
 		and <i>x</i>
-		is +0, the result is an implementation-dependent approximation to 
+		is +0, the result is an implementation-dependent approximation to
 		<span class="symbol">−π</span>/2.</p>
 		</li>
 		<li><p>
@@ -26575,7 +26576,7 @@ with arguments <i>obj </i>and <i>Properties</i>.</p>
 	weekday for a particular time value <i>t</i>
 	is defined as</p>
 	<p class="code-example">
-	WeekDay(<i>t</i>)	
+	WeekDay(<i>t</i>)
 	= (<a href="#x15.9.1.2">Day</a>(<i>t</i>) + 4) <a href="#modulo">modulo</a> 7</p>
 	<p>
 	A
@@ -27030,7 +27031,7 @@ value of an absent time zone offset is “<code>Z</code>”.</p>
 		</li>
 		<li><p>
 		If
-		<a href="#Type">Type</a>(<i>v</i>) is String, then 
+		<a href="#Type">Type</a>(<i>v</i>) is String, then
 		</p>
 		<ol>
 			<li><p>
@@ -28226,7 +28227,7 @@ value of an absent time zone offset is “<code>Z</code>”.</p>
 	kinds of objects for use as a method. However, it does require that
 	any such object have a <code><b>toISOString</b></code>
 	method. An object is free to use the argument <i>key</i>
-	to filter its stringification. 
+	to filter its stringification.
 	</p>
 	<h4 id="x15.9.6">15.9.6 Properties of Date Instances <a href="#x15.9.6">#</a> <a href="#x15.9.6-toc" class="bak">Ⓣ</a> <b class="erra">Ⓔ</b> <b class="rev1">①</b> <b class="anno">Ⓐ</b></h4>
 	<p>
@@ -28337,7 +28338,7 @@ value of an absent time zone offset is “<code>Z</code>”.</p>
 	<p class="def1-btm">
 	<code><b>a
 	 b  c  d  e  f  g  h  i  j  k  l  m  n  o  p  q  r  s  t  u  v  w  x
-	 y  z<br>A  B  C  D  E  F  G  H  I  J  K  L  M  N  O  P  Q  R  S  T 
+	 y  z<br>A  B  C  D  E  F  G  H  I  J  K  L  M  N  O  P  Q  R  S  T
 	U  V  W  X  Y  Z</b></code></p>
 	<p class="keep">
 	<i>IdentityEscape </i><b>::</b></p>
@@ -29827,8 +29828,8 @@ value of an absent time zone offset is “<code>Z</code>”.</p>
 					<i>c</i>(<i>y</i>) and return its result.</p>
 				</li></ol>
 			</li></ol>
-		
-	
+
+
 	<p>
 	The
 	abstract operation <dfn id="Canonicalize"><i>Canonicalize </i></dfn> takes a character parameter <i>ch</i>
@@ -30096,7 +30097,7 @@ value of an absent time zone offset is “<code>Z</code>”.</p>
 	The
 	production <i>CharacterEscape</i>
 	<b>:: </b><i>ControlEscape</i>
-	evaluates by returning the character according to Table 23 
+	evaluates by returning the character according to Table 23
 	</p>
 	<center>
 		<table width="507" border="1" bordercolor="#000000" cellpadding="8" cellspacing="0" rules="GROUPS">
@@ -31008,7 +31009,7 @@ value of an absent time zone offset is “<code>Z</code>”.</p>
 	[[Match]] internal property obtained by
 	evaluating ("compiling") the characters of <i>P</i>
 	as a <i>Pattern</i>
-	as described in <a href="#x15.10.2">15.10.2</a>. 
+	as described in <a href="#x15.10.2">15.10.2</a>.
 	</p>
 	<p>
 	If
@@ -31018,12 +31019,12 @@ value of an absent time zone offset is “<code>Z</code>”.</p>
 	or <code><b>"m"</b></code>,
 	or if it contains the same character more than once, then throw a
 	<b><a href="#x15.11.6.4" class="term-ref">SyntaxError</a></b>
-	exception. 
+	exception.
 	</p>
 	<p>
 	If
 	a <b><a href="#x15.11.6.4" class="term-ref">SyntaxError</a></b>
-	exception is not thrown, then: 
+	exception is not thrown, then:
 	</p>
 	<p>
 	Let
@@ -31037,7 +31038,7 @@ value of an absent time zone offset is “<code>Z</code>”.</p>
 	as a <i>Pattern</i>
 	must behave identically to the internal procedure given by the
 	constructed object's [[Match]] internal property.
-	
+
 	</p>
 	<p>
 	The
@@ -31066,7 +31067,7 @@ value of an absent time zone offset is “<code>Z</code>”.</p>
 	If <i>P</i>
 	is the empty String, this specification can be met by letting <i>S</i>
 	be <code><b>"(?:)"</b></code>.
-	
+
 	</p>
 	<p>
 	The
@@ -31119,7 +31120,7 @@ value of an absent time zone offset is “<code>Z</code>”.</p>
 	backslash <code><b>\</b></code>
 	characters must be escaped within the <i><a href="#x7.8.4">StringLiteral</a></i>
 	to prevent them being removed when the contents of the <i><a href="#x7.8.4">StringLiteral</a></i>
-	are formed. 
+	are formed.
 	</p>
 	<h4 id="x15.10.5">15.10.5 Properties of the RegExp Constructor <a href="#x15.10.5">#</a> <a href="#x15.10.5-toc" class="bak">Ⓣ</a> <b class="erra">Ⓔ</b> <b class="rev1">①</b> <b class="anno">Ⓐ</b></h4>
 	<p>
@@ -31245,7 +31246,7 @@ value of an absent time zone offset is “<code>Z</code>”.</p>
 			</li>
 			<li><p>
 			If
-			[[Match]] returned <b>failure</b>, then 
+			[[Match]] returned <b>failure</b>, then
 			</p>
 			<ol>
 				<li><p>
@@ -31255,7 +31256,7 @@ value of an absent time zone offset is “<code>Z</code>”.</p>
 			</li>
 			<li><p>
 			else
-			
+
 			</p>
 			<ol>
 				<li><p>
@@ -31391,7 +31392,7 @@ value of an absent time zone offset is “<code>Z</code>”.</p>
 	returned String has the form of a
 	<i><a href="#x7.8.5">RegularExpressionLiteral</a></i>
 	that evaluates to another RegExp object with the same
-	behaviour as this object. 
+	behaviour as this object.
 	</p>
 	<h4 id="x15.10.7">15.10.7 Properties of RegExp Instances <a href="#x15.10.7">#</a> <a href="#x15.10.7-toc" class="bak">Ⓣ</a> <b class="erra">Ⓔ</b> <b class="rev1">①</b> <b class="anno">Ⓐ</b></h4>
 	<p>
@@ -31789,7 +31790,7 @@ value of an absent time zone offset is “<code>Z</code>”.</p>
 		<i>JSONValue</i> rather
 		than being restricted to being  a <i>JSONObject</i>
 		or a <i>JSONArray</i> as
-		specified by RFC 4627. 
+		specified by RFC 4627.
 		</p>
 		</li>
 		<li><p>
@@ -31849,7 +31850,7 @@ value of an absent time zone offset is “<code>Z</code>”.</p>
 	<i>JSONStringCharacters </i><b>::</b></p>
 	<p class="def1">
 	<i>JSONStringCharacter
-	JSONStringCharacters</i><sub>opt</sub> 
+	JSONStringCharacters</i><sub>opt</sub>
 	</p>
 	<p>
 	<i>JSONStringCharacter </i><b>::</b></p>
@@ -31893,7 +31894,7 @@ value of an absent time zone offset is “<code>Z</code>”.</p>
 	The
 	JSON Syntactic Grammar defines a valid JSON text in terms of tokens
 	defined by the JSON lexical grammar.  The goal symbol of the grammar
-	is <i>JSONText</i>. 
+	is <i>JSONText</i>.
 	</p>
 	<p class="tiny-btm">
 	<b>Syntax</b></p>
@@ -31967,7 +31968,7 @@ value of an absent time zone offset is “<code>Z</code>”.</p>
 		Parse
 		<i>JText</i> using the grammars in <a href="#x15.12.1">15.12.1</a>. Throw a <b><a href="#x15.11.6.4" class="term-ref">SyntaxError</a></b>
 		exception if <i>JText</i> did not conform to the JSON grammar for
-		the goal symbol <i>JSONText</i>. 
+		the goal symbol <i>JSONText</i>.
 		</p>
 		</li>
 		<li><p>
@@ -32043,7 +32044,7 @@ value of an absent time zone offset is “<code>Z</code>”.</p>
 				</li>
 				<li><p>
 				Repeat
-				while <i>I </i>&lt; <i>len</i>, 
+				while <i>I </i>&lt; <i>len</i>,
 				</p>
 				<ol>
 					<li><p>
@@ -32058,7 +32059,7 @@ value of an absent time zone offset is “<code>Z</code>”.</p>
 						<li><p>
 						Call
 						the [[Delete]] internal method of <i>val</i> with <a href="#x9.8">ToString</a>(<i>I</i>)
-						and <b>false</b> as arguments. 
+						and <b>false</b> as arguments.
 						</p>
 					</li></ol>
 					</li>
@@ -32093,13 +32094,13 @@ value of an absent time zone offset is “<code>Z</code>”.</p>
 				</li>
 				<li><p>
 				For
-				each String <i>P</i> in <i>keys</i> do, 
+				each String <i>P</i> in <i>keys</i> do,
 				</p>
 				<ol>
 					<li><p>
 					Let
 					<i>newElement</i> be the result of calling the abstract
-					operation <a href="#Walk">Walk</a>, passing <i>val</i> and <i>P</i>. 
+					operation <a href="#Walk">Walk</a>, passing <i>val</i> and <i>P</i>.
 					</p>
 					</li>
 					<li><p>
@@ -32109,7 +32110,7 @@ value of an absent time zone offset is “<code>Z</code>”.</p>
 						<li><p>
 						Call
 						the [[Delete]] internal method of <i>val</i> with <i>P</i> and
-						<b>false</b> as arguments. 
+						<b>false</b> as arguments.
 						</p>
 					</li></ol>
 					</li>
@@ -32138,7 +32139,7 @@ value of an absent time zone offset is “<code>Z</code>”.</p>
 	not permitted for a conforming implementation of <code><b>JSON.parse</b></code>
 	to extend the JSON grammars. If an implementation wishes to support
 	a modified or extended JSON interchange format it must do so by
-	defining a different parse function. 
+	defining a different parse function.
 	</p>
 	<p><b class="note">NOTE</b> In
 	the case where there are duplicate name Strings within an object,
@@ -32455,7 +32456,7 @@ value of an absent time zone offset is “<code>Z</code>”.</p>
 	The
 	abstract operation <dfn id="Quote"><i>Quote</i>(<i>value</i>)</dfn>
 	wraps a String value in double quotes and escapes characters within
-	it. 
+	it.
 	</p>
 	<ol>
 		<li><p>
@@ -32664,7 +32665,7 @@ value of an absent time zone offset is “<code>Z</code>”.</p>
 				element Strings of <i>partial</i> with each adjacent pair of
 				Strings separated with the comma character. A comma is not
 				inserted either before the first String or after the last String.
-				
+
 				</p>
 				</li>
 				<li><p>
@@ -32760,7 +32761,7 @@ value of an absent time zone offset is “<code>Z</code>”.</p>
 			<li><p>
 			Let
 			<i>strP</i> be the result of calling the abstract operation <i>Str</i>
-			with arguments <a href="#x9.8">ToString</a>(<i>index</i>) and <i>value</i>. 
+			with arguments <a href="#x9.8">ToString</a>(<i>index</i>) and <i>value</i>.
 			</p>
 			</li>
 			<li><p>
@@ -32808,7 +32809,7 @@ value of an absent time zone offset is “<code>Z</code>”.</p>
 				element Strings of <i>partial</i> with each adjacent pair of
 				Strings separated with the comma character. A comma is not
 				inserted either before the first String or after the last String.
-				
+
 				</p>
 				</li>
 				<li><p>
@@ -32975,7 +32976,7 @@ value of an absent time zone offset is “<code>Z</code>”.</p>
 	even if the compiler can prove that a construct cannot execute
 	without error under any circumstances. An implementation may issue
 	an early warning in such a case, but it should not report the error
-	until the relevant construct is actually executed. 
+	until the relevant construct is actually executed.
 	</p>
 	<p>
 	An
@@ -34396,7 +34397,7 @@ value of an absent time zone offset is “<code>Z</code>”.</p>
 	<p class="def1-btm">
 	<code><b>a
 	 b  c  d  e  f  g  h  i  j  k  l  m  n  o  p  q  r  s  t  u  v  w  x
-	 y  z<br>A  B  C  D  E  F  G  H  I  J  K  L  M  N  O  P  Q  R  S  T 
+	 y  z<br>A  B  C  D  E  F  G  H  I  J  K  L  M  N  O  P  Q  R  S  T
 	U  V  W  X  Y  Z</b></code></p>
 	<p class="keep">
 	<i>uriMark </i><b>:::</b>
@@ -34485,7 +34486,7 @@ value of an absent time zone offset is “<code>Z</code>”.</p>
 	<p class="def1-btm">
 	<code><b>a
 	 b  c  d  e  f  g  h  i  j  k  l  m  n  o  p  q  r  s  t  u  v  w  x
-	 y  z<br>A  B  C  D  E  F  G  H  I  J  K  L  M  N  O  P  Q  R  S  T 
+	 y  z<br>A  B  C  D  E  F  G  H  I  J  K  L  M  N  O  P  Q  R  S  T
 	U  V  W  X  Y  Z</b></code></p>
 	<p class="keep">
 	<i>IdentityEscape </i><b>::</b><i class="see">See <a href="#x15.10.1">15.10.1</a></i></p>
@@ -34566,7 +34567,7 @@ value of an absent time zone offset is “<code>Z</code>”.</p>
 	<i>JSONStringCharacters </i><b>::</b><i class="see">See <a href="#x15.12.1.1">15.12.1.1</a></i></p>
 	<p class="def1">
 	<i>JSONStringCharacter
-	JSONStringCharacters</i><sub>opt</sub> 
+	JSONStringCharacters</i><sub>opt</sub>
 	</p>
 	<p class="keep">
 	<i>JSONStringCharacter </i><b>::</b><i class="see">See <a href="#x15.12.1.1">15.12.1.1</a></i></p>
@@ -35295,7 +35296,7 @@ within strict mode code.  (<a>7.6.12</a> [?]<!-- FIXME -->).</li>
 		of an Assignment operator (<a href="#x11.13">11.13</a>) or of a <i>PostfixExpression</i>
 		(<a href="#x11.3">11.3</a>) or as the <i>UnaryExpression</i>
 		operated upon by a Prefix Increment (<a href="#x11.4.4">11.4.4</a>) or a Prefix Decrement
-		(<a href="#x11.4.5">11.4.5</a>) operator. 
+		(<a href="#x11.4.5">11.4.5</a>) operator.
 		</p>
 		</li>
 		<li><p>
@@ -35462,7 +35463,7 @@ is thrown if the property to
 	invocations of standard built-in objects and methods has been
 	clarified by making it explicit that the intent is that the actual
 	built-in object is to be used rather than the current dynamic value
-	of the correspondingly named property. 
+	of the correspondingly named property.
 	</p>
 	<p>
 	<a href="#x11.8.2">11.8.2</a>,
@@ -35592,7 +35593,7 @@ is thrown if the property to
 	arguments object is <code><b>"Arguments"</b></code>.
 	 In Edition 3, it was <code><b>"Object"</b></code>.
 	This is observable if <code><b>toString</b></code>
-	is called as a method of an arguments object. 
+	is called as a method of an arguments object.
 	</p>
 	<p>
 	<a href="#x12.6.4">12.6.4</a>:
@@ -35603,7 +35604,7 @@ is thrown if the property to
 	<p>
 	<a href="#x15">15</a>:
 	In Edition 5, the following new properties are defined on built-in
-	objects that exist in Edition 3: 
+	objects that exist in Edition 3:
 <code><b>Object.getPrototypeOf</b></code>,
 <code><b>Object.getOwnPropertyDescriptor</b></code>,
 <code><b>Object.getOwnPropertyNames</b></code>,
@@ -35699,7 +35700,7 @@ is thrown if the property to
 	non-configurable and shadow any inherited properties with the same
 	names. In Edition 3, these properties did not exist and ECMAScript
 	code could dynamically add and remove writable properties with such
-	names and could access inherited properties with such names.  
+	names and could access inherited properties with such names.
 	</p>
 	<p>
 	<a href="#x15.9.4.2">15.9.4.2</a>:
@@ -35730,7 +35731,7 @@ is thrown if the property to
 	<a href="#x15.11.2.1">15.11.2.1</a>,
 	<a href="#x15.11.4.3">15.11.4.3</a>:  In Edition 5, if an initial value for the <code><b>message</b></code>
 	property of an Error object is not specified via the <code><b>Error</b></code>
-	constructor the initial value of the property is the empty String. 
+	constructor the initial value of the property is the empty String.
 	In Edition 3, such an initial value is implementation defined.</p>
 	<p>
 	<a href="#x15.11.4.4">15.11.4.4</a>:

--- a/introduction.html
+++ b/introduction.html
@@ -52,7 +52,7 @@
 	develop a fourth edition of ECMAScript. Although that work was not
 	completed and not published
 	<a class="footnote" id="sdfootnote1anc" href="#sdfootnote1sym">[1]</a>
-	
+
 	as the fourth edition of ECMAScript, it informs continuing evolution
 	of the language. The present fifth edition of ECMAScript (published
 	as ECMA-262 5<sup>th</sup>

--- a/multi.html
+++ b/multi.html
@@ -11,8 +11,9 @@
 <p><b class="other">This is <i>not</i> the normative ECMAScript Language specification.</b>
 The normative spec
 (<a href="http://www.ecmascript.org/">ECMA 262</a>)
-is a PDF file maintained by ECMA TC39 and is available from 
-<a href="http://www.ecmascript.org/">http://www.ecmascript.org/</a></p>
+is a PDF file maintained by ECMA TC39 and is available from
+<a href="http://www.ecmascript.org/">http://www.ecmascript.org/</a>. An auto-generated
+HTML version is available, too: <a href="http://ecma-international.org/ecma-262/5.1/">http://ecma-international.org/ecma-262/5.1/</a></p>
 </div>
 
 <p>This is an <b>annotated, hyperlinked, HTML version</b> of Edition 5.1 of

--- a/spec.html
+++ b/spec.html
@@ -11,8 +11,9 @@
 <p><b class="other">This is <i>not</i> the normative ECMAScript Language specification.</b>
 The normative spec
 (<a href="http://www.ecmascript.org/">ECMA 262</a>)
-is a PDF file maintained by ECMA TC39 and is available from 
-<a href="http://www.ecmascript.org/">http://www.ecmascript.org/</a></p>
+is a PDF file maintained by ECMA TC39 and is available from
+<a href="http://www.ecmascript.org/">http://www.ecmascript.org/</a>. An auto-generated
+HTML version is available, too: <a href="http://ecma-international.org/ecma-262/5.1/">http://ecma-international.org/ecma-262/5.1/</a></p>
 </div>
 
 <p>This is an <b>annotated, hyperlinked, HTML version</b> of Edition 5.1 of

--- a/x10.html
+++ b/x10.html
@@ -79,7 +79,7 @@
 	 <a href="#eval-code">Eval code</a> is strict eval code if it begins with a Directive Prologue
 		that contains a Use Strict Directive or if the call to eval is a
 		direct call (see <a href="x15.1.html#x15.1.2.1.1">15.1.2.1.1</a>) to the <a href="x15.1.html#x15.1.2.1">eval function</a> that is contained
-		in <a href="#x10.1.1" class="term-ref">strict mode code</a>. 
+		in <a href="#x10.1.1" class="term-ref">strict mode code</a>.
 		</p>
 		</li>
 		<li><p>
@@ -124,7 +124,7 @@
 	Lexical Environment values. The outer reference of a (inner) Lexical
 	Environment is a reference to the Lexical Environment that logically
 	surrounds the inner Lexical Environment. An outer Lexical
-	Environment may, of course, have its own outer Lexical Environment. 
+	Environment may, of course, have its own outer Lexical Environment.
 	A Lexical Environment may serve as the outer environment for
 	multiple inner Lexical Environments. For example, if a
 	<i><a href="x13.html#x13">FunctionDeclaration</a></i>
@@ -163,7 +163,7 @@
  and object environment record. The
 	abstract class includes the abstract specification methods defined
 	in Table 17. These abstract methods have distinct concrete
-	algorithms for each of the concrete subclasses. 
+	algorithms for each of the concrete subclasses.
 	</p>
 	<center>
 		<table width="690" border="1" bordercolor="#000000" cellpadding="8" cellspacing="0" rules="ROWS"><caption>Table&#160;17 &#8212; Abstract Methods of Environment Records</caption>
@@ -199,7 +199,7 @@
 					a new mutable binding in an environment record. The String value
 					<i>N</i> is the text
 					of the bound name. If the optional Boolean argument <i>D</i>
-					is <b>true</b> the binding is may be subsequently deleted.  
+					is <b>true</b> the binding is may be subsequently deleted.
 					</p>
 				</td>
 			</tr><tr valign="TOP"><td width="211" height="76">
@@ -233,7 +233,7 @@
 					is used to identify strict mode references. If <i>S</i>
 					is <b>true</b> and
 					the binding does not exist or is uninitialized throw a
-					<b><a href="x15.11.html#x15.11.6.3" class="term-ref">ReferenceError</a></b> exception. 
+					<b><a href="x15.11.html#x15.11.6.3" class="term-ref">ReferenceError</a></b> exception.
 					</p>
 				</td>
 			</tr><tr valign="TOP"><td width="211" height="58">
@@ -256,7 +256,7 @@
 					<p>Returns
 					the value to use as the <b>this</b> value on calls to function
 					objects that are obtained as binding values from this
-					environment record. 
+					environment record.
 					</p>
 				</td>
 			</tr></tbody></table></center>
@@ -307,7 +307,7 @@
 					the value of an already existing but uninitialized <a href="#immutable-binding">immutable binding</a> in an environment record. The String value <i>N</i>
 					is the text of the bound name. <i>V</i>
 					is the value for the binding and is a value of any ECMAScript
-					<a href="x8.html#language-type">language type</a>. 
+					<a href="x8.html#language-type">language type</a>.
 					</p>
 				</td>
 			</tr></tbody></table></center>
@@ -374,7 +374,7 @@
 	must already exist. If the binding is an <a href="#immutable-binding">immutable binding</a>, a
 	<b>TypeError</b> is
 	thrown
-	if <i>S</i> is <b>true</b>. 
+	if <i>S</i> is <b>true</b>.
 	</p>
 
 	<ol><li><p>
@@ -496,7 +496,7 @@
 	argument <i>N</i> to the
 	value of argument <i>V</i>.
 	An uninitialized <a href="#immutable-binding">immutable binding</a> for <i>N</i>
-	must already exist. 
+	must already exist.
 	</p>
 	<ol><li><p>
 		Let
@@ -819,7 +819,7 @@
 	As
 	ECMAScript code is executed, additional properties may be added to
 	the <a href="x15.1.html#x15.1" class="term-ref">global object</a> and the initial properties may be modified.
-	
+
 	</p>
 	<h3 id="x10.3">10.3 Execution Contexts <a href="#x10.3">#</a> <a href="#x10.3-toc" class="bak">&#9417;</a> <b class="erra">&#9402;</b> <b class="rev1">&#9312;</b> <b class="anno">&#9398;</b></h3>
 	<p>
@@ -902,7 +902,7 @@
 	execution context is purely a specification mechanism and need not
 	correspond to any particular artefact of an ECMAScript
 	implementation.  It is impossible for an ECMAScript program to
-	access an execution context. 
+	access an execution context.
 	</p>
 	<h4 id="x10.3.1">10.3.1 Identifier Resolution <a href="#x10.3.1">#</a> <a href="#x10.3.1-toc" class="bak">&#9417;</a> <b class="erra">&#9402;</b> <b class="rev1">&#9312;</b> <b class="anno">&#9398;</b></h4>
 	<p>
@@ -1066,7 +1066,7 @@
 		</li>
 		<li><p>
 		Let
-		<i>localEnv</i> be the result of calling <a href="#x10.2.2.2">NewDeclarativeEnvironment</a> 
+		<i>localEnv</i> be the result of calling <a href="#x10.2.2.2">NewDeclarativeEnvironment</a>
 		passing the value of the [[Scope]] internal property of <i>F</i> as
 		the argument.</p>
 		</li>
@@ -1124,7 +1124,7 @@
 			Let
 			<i>func </i>be the function whose [[Call]] internal method
 			initiated execution of <i>code</i>. Let <i>names</i> be the value
-			of <i>func</i>&#8217;s [[FormalParameters]] internal property.  
+			of <i>func</i>&#8217;s [[FormalParameters]] internal property.
 			</p>
 			</li>
 			<li><p>
@@ -1236,7 +1236,7 @@
 			</li>
 			<li><p>
 			If
-			<i>strict</i> is <b>true</b>, then 
+			<i>strict</i> is <b>true</b>, then
 			</p>
 			<ol><li><p>
 				Call
@@ -1360,7 +1360,7 @@
 		</li>
 		<li><p>
 		Repeat
-		while <i>indx</i> &gt;= 0, 
+		while <i>indx</i> &gt;= 0,
 		</p>
 		<ol><li><p>
 			Let
@@ -1540,7 +1540,7 @@
 		</li></ol></li>
 		<li><p>
 		Else,
-		<i>map</i> contains a formal parameter mapping for <i>P</i> so, 
+		<i>map</i> contains a formal parameter mapping for <i>P</i> so,
 		</p>
 		<ol><li><p>
 			Return
@@ -1582,7 +1582,7 @@
 		</li></ol></li>
 		<li><p>
 		Return
-		<i>desc</i>. 
+		<i>desc</i>.
 		</p>
 	</li></ol><p>
 	The

--- a/x11.html
+++ b/x11.html
@@ -258,7 +258,7 @@
 		Return
 		<i>preceding</i>+1.</p>
 	</li></ol><p class="sp">
-	</p><p><b class="note">NOTE</b> 
+	</p><p><b class="note">NOTE</b>
 	[[DefineOwnProperty]] is used to ensure that own properties are
 	defined for the array even if the standard built-in Array prototype
 	object has been modified in a manner that would preclude the
@@ -1616,7 +1616,7 @@ IEEE 754 round-to-nearest mode.
 		</li>
 		<li><p>
 		If
-		<a href="x8.html#Type">Type</a>(<i>lprim</i>) is String or <a href="x8.html#Type">Type</a>(<i>rprim</i>) is String, then 
+		<a href="x8.html#Type">Type</a>(<i>lprim</i>) is String or <a href="x8.html#Type">Type</a>(<i>rprim</i>) is String, then
 		</p>
 		<ol><li><p>
 			Return
@@ -2097,7 +2097,7 @@ IEEE 754 round-to-nearest mode.
 		<li><p>
 		If
 		it is not the case that both <a href="x8.html#Type">Type</a>(<i>px</i>) is String and <a href="x8.html#Type">Type</a>(<i>py</i>)
-		is String, then 
+		is String, then
 		</p>
 		<ol><li><p>
 			Let

--- a/x12.html
+++ b/x12.html
@@ -1120,7 +1120,7 @@
 				<li><p>
 				If<i>C</i>
 				has a <i>StatementList</i>,
-				then 
+				then
 				</p>
 				<ol><li><p>
 					Evaluate<i>C</i>&#8217;s
@@ -1149,7 +1149,7 @@
 			<li><p>
 			If<i>C</i>
 			has a <i>StatementList</i>,
-			then 
+			then
 			</p>
 			<ol><li><p>
 				Evaluate<i>C</i>&#8217;s
@@ -1256,7 +1256,7 @@
 		If
 		<i>found</i>
 		is <b>false</b>,
-		then 
+		then
 		</p>
 		<ol><li><p class="sm-btm">
 			Repeat,
@@ -1269,7 +1269,7 @@
 				<i>C</i>
 				be the next <i>CaseClause</i>
 				in <i>B</i>.
-				
+
 				</p>
 				</li>
 				<li><p class="sm-btm">
@@ -1354,7 +1354,7 @@
 			<li><p class="sm-btm">
 			If
 			<i>C</i>
-			has a StatementList, then 
+			has a StatementList, then
 			</p>
 			<ol><li><p class="sm-btm">
 				Evaluate
@@ -1592,7 +1592,7 @@
 		<li><p>
 		Let
 		<i>catchEnv</i> be the result of calling <a href="x10.html#x10.2.2.2">NewDeclarativeEnvironment</a>
-		passing <i>oldEnv</i> as the argument. 
+		passing <i>oldEnv</i> as the argument.
 		</p>
 		</li>
 		<li><p>
@@ -1669,7 +1669,7 @@
 			</li>
 			<li><p>
 			Let
-			<i>result</i> be an implementation defined <a href="x8.html#x8.9">Completion</a> value. 
+			<i>result</i> be an implementation defined <a href="x8.html#x8.9">Completion</a> value.
 			</p>
 		</li></ol></li>
 		<li><p>

--- a/x13.html
+++ b/x13.html
@@ -272,7 +272,7 @@
 		[[Enumerable]]: <b>false</b>,
 		[[Configurable]]: <b>false</b>},
 		and <b>false</b>.
-		
+
 		</p>
 		</li>
 		<li><p>
@@ -494,7 +494,7 @@
 		[[Enumerable]]: <b>false</b>,
 		[[Configurable]]: <b>false</b>},
 		and <b>false</b>.
-		
+
 		</p>
 		</li>
 		<li><p>

--- a/x14.html
+++ b/x14.html
@@ -56,7 +56,7 @@
 		<li><p>
 		Let
 		<i>progCxt</i> be a new execution context for <a href="x10.html#global-code">global code</a> as
-		described in <a href="x10.html#x10.4.1">10.4.1</a>. 
+		described in <a href="x10.html#x10.4.1">10.4.1</a>.
 		</p>
 		</li>
 		<li><p>
@@ -100,7 +100,7 @@
 		</li>
 		<li><p>
 		Return
-		(tailResult.type, V, tailResult.target) 
+		(tailResult.type, V, tailResult.target)
 		</p>
 	</li></ol><p>
 	The

--- a/x15.1.html
+++ b/x15.1.html
@@ -26,7 +26,7 @@
 	<p>
 	The
 	unique <i><a href="#x15.1" class="term-ref">global object</a></i> is created before control enters any
-	execution context. 
+	execution context.
 	</p>
 	<p>
 	Unless
@@ -426,7 +426,7 @@ If <i>inputString</i> does not contain any such characters, let
 	<p class="def1-btm">
 	<code><b>a
 	 b  c  d  e  f  g  h  i  j  k  l  m  n  o  p  q  r  s  t  u  v  w  x
-	 y  z<br>A  B  C  D  E  F  G  H  I  J  K  L  M  N  O  P  Q  R  S  T 
+	 y  z<br>A  B  C  D  E  F  G  H  I  J  K  L  M  N  O  P  Q  R  S  T
 	U  V  W  X  Y  Z</b></code></p>
 	<p class="keep">
 	<i>uriMark </i><b>:::</b> <b>one
@@ -506,7 +506,7 @@ If <i>inputString</i> does not contain any such characters, let
 				</li></ol></li>
 				<li><p>
 				Else,
-				
+
 				</p>
 				<ol><li><p>
 					Increase

--- a/x15.10.html
+++ b/x15.10.html
@@ -121,7 +121,7 @@
 	<p class="def1-btm">
 	<code><b>a
 	 b  c  d  e  f  g  h  i  j  k  l  m  n  o  p  q  r  s  t  u  v  w  x
-	 y  z<br>A  B  C  D  E  F  G  H  I  J  K  L  M  N  O  P  Q  R  S  T 
+	 y  z<br>A  B  C  D  E  F  G  H  I  J  K  L  M  N  O  P  Q  R  S  T
 	U  V  W  X  Y  Z</b></code></p>
 	<p class="keep">
 	<i>IdentityEscape </i><b>::</b></p>
@@ -1716,7 +1716,7 @@
 	The
 	production <i>CharacterEscape</i>
 	<b>:: </b><i>ControlEscape</i>
-	evaluates by returning the character according to Table 23 
+	evaluates by returning the character according to Table 23
 	</p>
 	<center>
 		<table width="507" border="1" bordercolor="#000000" cellpadding="8" cellspacing="0" rules="GROUPS"><caption>Table&#160;23 &#8212; ControlEscape Character Values</caption>
@@ -2546,7 +2546,7 @@
 	[[Match]] internal property obtained by
 	evaluating ("compiling") the characters of <i>P</i>
 	as a <i>Pattern</i>
-	as described in <a href="#x15.10.2">15.10.2</a>. 
+	as described in <a href="#x15.10.2">15.10.2</a>.
 	</p>
 	<p>
 	If
@@ -2556,12 +2556,12 @@
 	or <code><b>"m"</b></code>,
 	or if it contains the same character more than once, then throw a
 	<b><a href="x15.11.html#x15.11.6.4" class="term-ref">SyntaxError</a></b>
-	exception. 
+	exception.
 	</p>
 	<p>
 	If
 	a <b><a href="x15.11.html#x15.11.6.4" class="term-ref">SyntaxError</a></b>
-	exception is not thrown, then: 
+	exception is not thrown, then:
 	</p>
 	<p>
 	Let
@@ -2575,7 +2575,7 @@
 	as a <i>Pattern</i>
 	must behave identically to the internal procedure given by the
 	constructed object's [[Match]] internal property.
-	
+
 	</p>
 	<p>
 	The
@@ -2604,7 +2604,7 @@
 	If <i>P</i>
 	is the empty String, this specification can be met by letting <i>S</i>
 	be <code><b>"(?:)"</b></code>.
-	
+
 	</p>
 	<p>
 	The
@@ -2657,7 +2657,7 @@
 	backslash <code><b>\</b></code>
 	characters must be escaped within the <i><a href="x7.html#x7.8.4">StringLiteral</a></i>
 	to prevent them being removed when the contents of the <i><a href="x7.html#x7.8.4">StringLiteral</a></i>
-	are formed. 
+	are formed.
 	</p>
 	<h4 id="x15.10.5">15.10.5 Properties of the RegExp Constructor <a href="#x15.10.5">#</a> <a href="#x15.10.5-toc" class="bak">&#9417;</a> <b class="erra">&#9402;</b> <b class="rev1">&#9312;</b> <b class="anno">&#9398;</b></h4>
 	<p>
@@ -2779,7 +2779,7 @@
 			</li>
 			<li><p>
 			If
-			[[Match]] returned <b>failure</b>, then 
+			[[Match]] returned <b>failure</b>, then
 			</p>
 			<ol><li><p>
 				<i>Let
@@ -2787,7 +2787,7 @@
 			</li></ol></li>
 			<li><p>
 			else
-			
+
 			</p>
 			<ol><li><p>
 				Let
@@ -2913,7 +2913,7 @@
 	returned String has the form of a
 	<i><a href="x7.html#x7.8.5">RegularExpressionLiteral</a></i>
 	that evaluates to another RegExp object with the same
-	behaviour as this object. 
+	behaviour as this object.
 	</p>
 	<h4 id="x15.10.7">15.10.7 Properties of RegExp Instances <a href="#x15.10.7">#</a> <a href="#x15.10.7-toc" class="bak">&#9417;</a> <b class="erra">&#9402;</b> <b class="rev1">&#9312;</b> <b class="anno">&#9398;</b></h4>
 	<p>

--- a/x15.12.html
+++ b/x15.12.html
@@ -33,7 +33,7 @@
 		<i>JSONValue</i> rather
 		than being restricted to being  a <i>JSONObject</i>
 		or a <i>JSONArray</i> as
-		specified by RFC 4627. 
+		specified by RFC 4627.
 		</p>
 		</li>
 		<li><p>
@@ -135,7 +135,7 @@
 	The
 	JSON Syntactic Grammar defines a valid JSON text in terms of tokens
 	defined by the JSON lexical grammar.  The goal symbol of the grammar
-	is <i>JSONText</i>. 
+	is <i>JSONText</i>.
 	</p>
 	<p class="tiny-btm">
 	<b>Syntax</b></p>
@@ -208,7 +208,7 @@
 		Parse
 		<i>JText</i> using the grammars in <a href="#x15.12.1">15.12.1</a>. Throw a <b><a href="x15.11.html#x15.11.6.4" class="term-ref">SyntaxError</a></b>
 		exception if <i>JText</i> did not conform to the JSON grammar for
-		the goal symbol <i>JSONText</i>. 
+		the goal symbol <i>JSONText</i>.
 		</p>
 		</li>
 		<li><p>
@@ -276,7 +276,7 @@
 				</li>
 				<li><p>
 				Repeat
-				while <i>I </i>&lt; <i>len</i>, 
+				while <i>I </i>&lt; <i>len</i>,
 				</p>
 				<ol><li><p>
 					Let
@@ -289,7 +289,7 @@
 					<ol><li><p>
 						Call
 						the [[Delete]] internal method of <i>val</i> with <a href="x9.html#x9.8">ToString</a>(<i>I</i>)
-						and <b>false</b> as arguments. 
+						and <b>false</b> as arguments.
 						</p>
 					</li></ol></li>
 					<li><p>
@@ -318,12 +318,12 @@
 				</li>
 				<li><p>
 				For
-				each String <i>P</i> in <i>keys</i> do, 
+				each String <i>P</i> in <i>keys</i> do,
 				</p>
 				<ol><li><p>
 					Let
 					<i>newElement</i> be the result of calling the abstract
-					operation <a href="#Walk">Walk</a>, passing <i>val</i> and <i>P</i>. 
+					operation <a href="#Walk">Walk</a>, passing <i>val</i> and <i>P</i>.
 					</p>
 					</li>
 					<li><p>
@@ -332,7 +332,7 @@
 					<ol><li><p>
 						Call
 						the [[Delete]] internal method of <i>val</i> with <i>P</i> and
-						<b>false</b> as arguments. 
+						<b>false</b> as arguments.
 						</p>
 					</li></ol></li>
 					<li><p>
@@ -354,7 +354,7 @@
 	not permitted for a conforming implementation of <code><b>JSON.parse</b></code>
 	to extend the JSON grammars. If an implementation wishes to support
 	a modified or extended JSON interchange format it must do so by
-	defining a different parse function. 
+	defining a different parse function.
 	</p>
 	<p><b class="note">NOTE</b> In
 	the case where there are duplicate name Strings within an object,
@@ -623,7 +623,7 @@
 	The
 	abstract operation <dfn id="Quote"><i>Quote</i>(<i>value</i>)</dfn>
 	wraps a String value in double quotes and escapes characters within
-	it. 
+	it.
 	</p>
 	<ol><li><p>
 		Let
@@ -805,7 +805,7 @@
 				element Strings of <i>partial</i> with each adjacent pair of
 				Strings separated with the comma character. A comma is not
 				inserted either before the first String or after the last String.
-				
+
 				</p>
 				</li>
 				<li><p>
@@ -894,7 +894,7 @@
 		<ol><li><p>
 			Let
 			<i>strP</i> be the result of calling the abstract operation <i>Str</i>
-			with arguments <a href="x9.html#x9.8">ToString</a>(<i>index</i>) and <i>value</i>. 
+			with arguments <a href="x9.html#x9.8">ToString</a>(<i>index</i>) and <i>value</i>.
 			</p>
 			</li>
 			<li><p>
@@ -933,7 +933,7 @@
 				element Strings of <i>partial</i> with each adjacent pair of
 				Strings separated with the comma character. A comma is not
 				inserted either before the first String or after the last String.
-				
+
 				</p>
 				</li>
 				<li><p>

--- a/x15.2.html
+++ b/x15.2.html
@@ -87,7 +87,7 @@
 		<li><p>
 		Asset:
 		The argument <i>value</i> was not supplied or its type was Null or
-		Undefined. 
+		Undefined.
 		</p>
 		</li>
 		<li><p>
@@ -181,7 +181,7 @@
 		<li><p>
 		Let
 		<i>array </i>be the result of creating a new object as if by the
-		expression <code><b>new Array ()</b></code>
+		expression <code><b>new Array()</b></code>
 		where <code><b>Array</b></code> is
 		the standard built-in constructor with that name.</p>
 		</li>
@@ -522,7 +522,7 @@ with arguments <i>obj </i>and <i>Properties</i>.</p>
 		<li><p>
 		For
 		each own enumerable property of <i>O</i> whose name String is <i>P</i>
-		
+
 		</p>
 		<ol><li><p>
 			Call
@@ -617,7 +617,7 @@ with arguments <i>obj </i>and <i>Properties</i>.</p>
 	<h5 id="x15.2.4.4">15.2.4.4 Object.prototype.valueOf ( ) <a href="#x15.2.4.4">#</a> <a href="#x15.2.4.4-toc" class="bak">&#9417;</a> <b class="erra">&#9402;</b> <b class="rev1">&#9312;</b> <b class="anno">&#9398;</b></h5>
 	<p>
 	When
-	the <b>valueOf</b> method is called, the following steps are taken: 
+	the <b>valueOf</b> method is called, the following steps are taken:
 	</p>
 	<ol><li><p>
 		Let

--- a/x15.3.html
+++ b/x15.3.html
@@ -145,7 +145,7 @@
 		<li><p>
 		If
 		<i>strict</i> is <b>true</b>, throw any exceptions specified in
-		<a href="x13.html#x13.1">13.1</a> that apply. 
+		<a href="x13.html#x13.1">13.1</a> that apply.
 		</p>
 		</li>
 		<li><p>
@@ -252,7 +252,7 @@
 	is called on an object <i>func</i>
 	with arguments <i>thisArg</i>
 	and <i>argArray</i>, the
-	following steps are taken: 
+	following steps are taken:
 	</p>
 	<ol><li><p>
 		If
@@ -450,7 +450,7 @@
 			<li><p>
 			Set
 			the <b>length </b>own property of <i>F </i>to either 0 or
-			<i>L</i>, whichever is larger. 
+			<i>L</i>, whichever is larger.
 			</p>
 		</li></ol></li>
 		<li><p>
@@ -605,7 +605,7 @@
 	&#8220;arguments&#8221; that throw a <b><a href="x15.11.html#x15.11.6.5" class="term-ref">TypeError</a></b> exception. An
 	ECMAScript implementation must not associate any implementation
 	specific behaviour  with accesses of these properties from strict
-	mode <a href="x10.html#function-code">function code</a>. 
+	mode <a href="x10.html#function-code">function code</a>.
 	</p>
 	<h5 id="x15.3.5.1">15.3.5.1 length <a href="#x15.3.5.1">#</a> <a href="#x15.3.5.1-toc" class="bak">&#9417;</a> <b class="erra">&#9402;</b> <b class="rev1">&#9312;</b> <b class="anno">&#9398;</b></h5>
 	<p>
@@ -698,7 +698,7 @@
 		If
 		<i>P</i> is <code><b>"caller"
 		</b></code>and <i>v</i> is a strict mode Function object, throw a
-		<b><a href="x15.11.html#x15.11.6.5" class="term-ref">TypeError</a></b> exception. 
+		<b><a href="x15.11.html#x15.11.6.5" class="term-ref">TypeError</a></b> exception.
 		</p>
 		</li>
 		<li><p>

--- a/x15.4.html
+++ b/x15.4.html
@@ -318,7 +318,7 @@
 		</li></ol></li>
 		<li><p>
 		Else
-		
+
 		</p>
 		<ol><li><p>
 			Let
@@ -338,7 +338,7 @@
 			Let
 			<i>R</i> be the result of calling the [[Call]] internal method of
 			<i>func</i> providing <i>elementObj</i> as the <b>this</b> value
-			and an empty arguments list. 
+			and an empty arguments list.
 			</p>
 		</li></ol></li>
 		<li><p>
@@ -367,7 +367,7 @@
 			</li></ol></li>
 			<li><p>
 			Else
-			
+
 			</p>
 			<ol><li><p>
 				Let
@@ -387,7 +387,7 @@
 				Let
 				<i>R</i> be the result of calling the [[Call]] internal method of
 				<i>func</i> providing <i>elementObj</i> as the <b>this</b> value
-				and an empty arguments list. 
+				and an empty arguments list.
 				</p>
 			</li></ol></li>
 			<li><p>
@@ -646,7 +646,7 @@
 		</li>
 		<li><p>
 		If
-		<i>len</i> is zero, 
+		<i>len</i> is zero,
 		</p>
 		<ol><li><p>
 			Call
@@ -1534,7 +1534,7 @@
 			</li>
 			<li><p>
 			Repeat,
-			while <i>k</i> &gt; (<i>len</i> &#8211;<i> actualDeleteCount</i> +<i>itemCount</i>) 
+			while <i>k</i> &gt; (<i>len</i> &#8211;<i> actualDeleteCount</i> +<i>itemCount</i>)
 			</p>
 			<ol><li><p>
 				Call
@@ -1670,7 +1670,7 @@
 		</li>
 		<li><p>
 		Repeat,
-		while <i>k</i> &gt; 0, 
+		while <i>k</i> &gt; 0,
 		</p>
 		<ol><li><p>
 			Let
@@ -1807,7 +1807,7 @@
 		</li>
 		<li><p>
 		If
-		<i>n </i>&#8805; 0, then 
+		<i>n </i>&#8805; 0, then
 		</p>
 		<ol><li><p>
 			Let
@@ -1996,7 +1996,7 @@
 	<code><b>every</b></code>
 	does not directly mutate the object on which it is called but the
 	object may be mutated by the calls to <i>callbackfn</i>.
-	
+
 	</p>
 	<p>
 	The
@@ -2233,13 +2233,13 @@
 	<p>
 	<i>callbackfn</i>
 	is called with three arguments: the value of the element, the index
-	of the element, and the object being traversed. 
+	of the element, and the object being traversed.
 	</p>
 	<p>
 	<code><b>forEach</b></code>
 	does not directly mutate the object on which it is called but the
 	object may be mutated by the calls to <i>callbackfn</i>.
-	
+
 	</p>
 	<p>
 	The
@@ -2364,7 +2364,7 @@
 	<p>
 	When
 	the <code><b>map</b></code> method is
-	called with one or two arguments, the following steps are taken: 
+	called with one or two arguments, the following steps are taken:
 	</p>
 	<ol><li><p>
 		Let
@@ -2494,7 +2494,7 @@
 	<p>
 	When
 	the <code><b>filter</b></code> method
-	is called with one or two arguments, the following steps are taken: 
+	is called with one or two arguments, the following steps are taken:
 	</p>
 	<ol><li><p>
 		Let
@@ -2630,7 +2630,7 @@
 	<p>
 	When
 	the <code><b>reduce</b></code> method
-	is called with one or two arguments, the following steps are taken: 
+	is called with one or two arguments, the following steps are taken:
 	</p>
 	<ol><li><p>
 		Let
@@ -2789,7 +2789,7 @@
 	<p>
 	When
 	the <code><b>reduceRight </b></code>method
-	is called with one or two arguments, the following steps are taken: 
+	is called with one or two arguments, the following steps are taken:
 	</p>
 	<ol><li><p>
 		Let
@@ -3054,7 +3054,7 @@
 					Call
 					the default [[DefineOwnProperty]] internal method (<a href="x8.html#x8.12.9">8.12.9</a>) on <i>A</i>
 					passing <b>"</b><code><b>length</b></code><b>"</b>,
-					<i>newLenDesc</i>, and <b>false</b> as arguments. 
+					<i>newLenDesc</i>, and <b>false</b> as arguments.
 					</p>
 					</li>
 					<li><p>

--- a/x15.5.html
+++ b/x15.5.html
@@ -1426,7 +1426,7 @@
 	by this String object. The array index named properties correspond
 	to the individual characters of the String value. A special
 	[[GetOwnProperty]] internal method is used to specify the number,
-	values, and attributes of the array index named properties. 
+	values, and attributes of the array index named properties.
 	</p>
 	<h5 id="x15.5.5.1">15.5.5.1 length <a href="#x15.5.5.1">#</a> <a href="#x15.5.5.1-toc" class="bak">&#9417;</a> <b class="erra">&#9402;</b> <b class="rev1">&#9312;</b> <b class="anno">&#9398;</b></h5>
 	<p>
@@ -1462,7 +1462,7 @@
 		</li>
 		<li><p>
 		If
-		<i>desc</i> is not <b>undefined </b>return <i>desc</i>. 
+		<i>desc</i> is not <b>undefined </b>return <i>desc</i>.
 		</p>
 		</li>
 

--- a/x15.7.html
+++ b/x15.7.html
@@ -337,7 +337,7 @@
 	may be more precise than <code><b>toString</b></code>
 	for some values because toString only prints enough significant
 	digits to distinguish the number from adjacent number values. For
-	example, 
+	example,
 	</p>
 	<p class="sp">(<code><b>1000000000000000128).toString()</b></code>
 	returns <code><b>"1000000000000000100"</b></code>,<br>while
@@ -387,7 +387,7 @@
 		<ol><li><p>
 			Return
 			the concatenation of the Strings <i>s</i> and <code><b>"Infinity"</b></code>.
-			
+
 			</p>
 		</li></ol></li>
 		<li><p>
@@ -428,7 +428,7 @@
 			</li></ol></li>
 			<li><p>
 			Else,
-			<i>fractionDigits</i> is <b>undefined</b> 
+			<i>fractionDigits</i> is <b>undefined</b>
 			</p>
 			<ol><li><p>
 				Let
@@ -461,7 +461,7 @@
 		</li></ol></li>
 		<li><p>
 		If
-		<i>e</i> = 0, then 
+		<i>e</i> = 0, then
 		</p>
 		<ol><li><p>
 			Let
@@ -653,7 +653,7 @@
 				<i>e</i> <span class="symbol">&#8800;</span> 0,</p>
 				<ol><li><p>
 					If
-					<i>e</i> &gt; 0,  then 
+					<i>e</i> &gt; 0,  then
 					</p>
 					<ol><li><p>
 						Let

--- a/x15.8.html
+++ b/x15.8.html
@@ -163,7 +163,7 @@
 	arithmetic contained in <code><b>fdlibm</b></code>,
 	the freely distributable mathematical library from Sun Microsystems
 	(<a href="http://www.netlib.org/fdlibm">http://www.netlib.org/fdlibm</a>).
-	
+
 	</p>
 	<h5 id="x15.8.2.1">15.8.2.1 abs (x) <a href="#x15.8.2.1">#</a> <a href="#x15.8.2.1-toc" class="bak">&#9417;</a> <b class="erra">&#9402;</b> <b class="rev1">&#9312;</b> <b class="anno">&#9398;</b></h5>
 	<p>
@@ -301,7 +301,7 @@
 		If
 		<i>y</i>&gt;0
 		and <i>x</i>
-		is +0, the result is an implementation-dependent approximation to 
+		is +0, the result is an implementation-dependent approximation to
 		+<span class="symbol">&#960;</span>/2.</p>
 		</li>
 		<li><p>
@@ -369,7 +369,7 @@
 		If
 		<i>y</i>&lt;0
 		and <i>x</i>
-		is +0, the result is an implementation-dependent approximation to 
+		is +0, the result is an implementation-dependent approximation to
 		<span class="symbol">&#8722;&#960;</span>/2.</p>
 		</li>
 		<li><p>

--- a/x15.9.html
+++ b/x15.9.html
@@ -213,7 +213,7 @@
 	weekday for a particular time value <i>t</i>
 	is defined as</p>
 	<p class="code-example">
-	WeekDay(<i>t</i>)	
+	WeekDay(<i>t</i>)
 	= (<a href="#x15.9.1.2">Day</a>(<i>t</i>) + 4) <a href="x5.html#modulo">modulo</a> 7</p>
 	<p>
 	A
@@ -641,7 +641,7 @@ value of an absent time zone offset is &#8220;<code>Z</code>&#8221;.</p>
 		</li>
 		<li><p>
 		If
-		<a href="x8.html#Type">Type</a>(<i>v</i>) is String, then 
+		<a href="x8.html#Type">Type</a>(<i>v</i>) is String, then
 		</p>
 		<ol><li><p>
 			Parse
@@ -1764,7 +1764,7 @@ value of an absent time zone offset is &#8220;<code>Z</code>&#8221;.</p>
 	kinds of objects for use as a method. However, it does require that
 	any such object have a <code><b>toISOString</b></code>
 	method. An object is free to use the argument <i>key</i>
-	to filter its stringification. 
+	to filter its stringification.
 	</p>
 	<h4 id="x15.9.6">15.9.6 Properties of Date Instances <a href="#x15.9.6">#</a> <a href="#x15.9.6-toc" class="bak">&#9417;</a> <b class="erra">&#9402;</b> <b class="rev1">&#9312;</b> <b class="anno">&#9398;</b></h4>
 	<p>

--- a/x15.html
+++ b/x15.html
@@ -95,7 +95,7 @@
 	behaviour corresponds to the invocation of the constructor&#8217;s
 	[[Call]] internal method and the &#8220;called as part of a new
 	expression&#8221; behaviour corresponds to the invocation of the
-	constructor&#8217;s [[Construct]] internal method. 
+	constructor&#8217;s [[Construct]] internal method.
 	</p>
 	<p>
 	Every

--- a/x16.html
+++ b/x16.html
@@ -87,7 +87,7 @@
 	even if the compiler can prove that a construct cannot execute
 	without error under any circumstances. An implementation may issue
 	an early warning in such a case, but it should not report the error
-	until the relevant construct is actually executed. 
+	until the relevant construct is actually executed.
 	</p>
 	<p>
 	An

--- a/x4.html
+++ b/x4.html
@@ -266,7 +266,7 @@ an object is a member of the remaining built-in type
 	A complete ECMAScript program may be composed for both strict mode
 	and non-strict mode ECMAScript code units. In this case, strict mode
 	only applies when actually executing code that is defined within a
-	<a href="x10.html#x10.1.1" class="term-ref">strict mode code</a> unit. 
+	<a href="x10.html#x10.1.1" class="term-ref">strict mode code</a> unit.
 	</p>
 	<p>
 	In
@@ -357,7 +357,7 @@ an object is a member of the remaining built-in type
 	<h4 id="x4.3.10">4.3.10<br><dfn id="Undefined_type">Undefined type</dfn> <a href="#x4.3.10">#</a> <a href="#x4.3.10-toc" class="bak">&#9417;</a> <b class="erra">&#9402;</b> <b class="rev1">&#9312;</b> <b class="anno">&#9398;</b></h4>
 	<p>
 	type
-	whose sole value is the undefined value. 
+	whose sole value is the undefined value.
 	</p>
 	<h4 id="x4.3.11">4.3.11<br><dfn id="null_value">null value</dfn> <a href="#x4.3.11">#</a> <a href="#x4.3.11-toc" class="bak">&#9417;</a> <b class="erra">&#9402;</b> <b class="rev1">&#9312;</b> <b class="anno">&#9398;</b></h4>
 	<p>
@@ -391,7 +391,7 @@ an object is a member of the remaining built-in type
 	<h4 id="x4.3.16">4.3.16<br><dfn id="String_value">String value</dfn> <a href="#x4.3.16">#</a> <a href="#x4.3.16-toc" class="bak">&#9417;</a> <b class="erra">&#9402;</b> <b class="rev1">&#9312;</b> <b class="anno">&#9398;</b></h4>
 	<p>
 	<a href="#primitive_value" class="term-ref">primitive value</a> that is a finite ordered sequence of zero or more 16-bit
-	unsigned integer. 
+	unsigned integer.
 	</p>
 	<p><b class="note">NOTE</b> A
 	String value is a member of the String type. Each integer value in
@@ -468,7 +468,7 @@ an object is a member of the remaining built-in type
 	and <code><b><a href="x15.8.html#x15.8.2.8">Math.exp</a></b></code>. An
 	implementation may provide implementation-dependent built-in
 	functions that are not described in this specification.
-	
+
 	</p>
 	<h4 id="x4.3.26">4.3.26<br><dfn id="property">property</dfn> <a href="#x4.3.26">#</a> <a href="#x4.3.26-toc" class="bak">&#9417;</a> <b class="erra">&#9402;</b> <b class="rev1">&#9312;</b> <b class="anno">&#9398;</b></h4>
 	<p>
@@ -492,7 +492,7 @@ an object is a member of the remaining built-in type
 	<p><b class="note">NOTE</b> Standard
 	built-in methods are defined in this specification, and an
 	ECMAScript implementation may specify and provide other additional
-	built-in methods. 
+	built-in methods.
 	</p>
 	<h4 id="x4.3.29">4.3.29<br><dfn id="attribute">attribute</dfn> <a href="#x4.3.29">#</a> <a href="#x4.3.29-toc" class="bak">&#9417;</a> <b class="erra">&#9402;</b> <b class="rev1">&#9312;</b> <b class="anno">&#9398;</b></h4>
 	<p>

--- a/x5.html
+++ b/x5.html
@@ -41,7 +41,7 @@
 	<p>
 	A
 	<i>lexical grammar</i> for ECMAScript is given in <a href="x7.html#x7">clause 7</a>. This
-	grammar has as its terminal symbols characters (Unicode code units) 
+	grammar has as its terminal symbols characters (Unicode code units)
 	that conform to the rules for <i>SourceCharacter</i>
 	defined in <a href="x6.html#x6">Clause 6</a>. It defines a set of productions, starting from
 	the goal symbol <i>InputElementDiv</i>
@@ -458,7 +458,7 @@
 	algorithm should terminate. The notation Result(<i>n</i>)
 	is used as shorthand for &#8220;the result
 	of step <i>n</i>&#8221;.
-	
+
 	</p>
 	<p>
 	For
@@ -467,7 +467,7 @@
 	further divided into indented substeps.  Outline numbering
 	conventions are used to identify substeps with the first level of
 	substeps labelled with lower case alphabetic characters and the
-	second level of substeps labelled with lower case roman numerals. 
+	second level of substeps labelled with lower case roman numerals.
 	If more than three levels are required these rules repeat with the
 	fourth level using numeric labels. For example:</p>
 	<ol><li><p>
@@ -478,7 +478,7 @@
 			</li>
 			<li><p>
 			Substep
-			
+
 			</p>
 			<ol><li><p>
 				Subsubstep.</p>

--- a/x7.html
+++ b/x7.html
@@ -90,7 +90,7 @@
 	distinctions when forming words or phrases in certain languages. In
 	ECMAScript source text, &lt;ZWNJ&gt;
 	and &lt;ZWJ&gt;
-	may also be used in an identifier after the first character. 
+	may also be used in an identifier after the first character.
 	</p>
 	<p>
 	&lt;BOM&gt;
@@ -100,7 +100,7 @@
 	characters intended for this purpose can sometimes also appear after
 	the start of a text, for example as a result of concatenating files.
 	&lt;BOM&gt; characters are treated as white space characters (see
-	<a href="#x7.2">7.2</a>). 
+	<a href="#x7.2">7.2</a>).
 	</p>
 	<p class="sm-btm">
 	The
@@ -323,13 +323,13 @@
 	cannot occur within any token except a <i><a href="#x7.8.4">StringLiteral</a></i>.
 	Line terminators may only occur within a <i><a href="#x7.8.4">StringLiteral</a></i>
 	token as part of a <i>LineContinuation</i>.
-	
+
 	</p>
 	<p>
 	A
 	line terminator can occur within a <i>MultiLineComment</i>
 	(<a href="#x7.4">7.4</a>) but cannot occur within a <i>SingleLineComment</i>.
-	
+
 	</p>
 	<p>
 	Line
@@ -375,7 +375,7 @@
 				<td width="152">
 					<p>
 					Carriage
-					Return 
+					Return
 					</p>
 				</td>
 				<td width="147">

--- a/x8.html
+++ b/x8.html
@@ -276,14 +276,14 @@ and
 		<i>named accessor property</i> associates a name with one or two
 		accessor functions, and a set of Boolean attributes. The accessor
 		functions are used to store or retrieve an ECMAScript language
-		value that is associated with the property. 
+		value that is associated with the property.
 		</p>
 		</li>
 		<li><p>
 		An
 		<i>internal property</i> has no name and is not directly accessible
 		via ECMAScript language operators. Internal properties exist purely
-		for specification purposes. 
+		for specification purposes.
 		</p>
 	</li></ul><p>
 	There
@@ -315,7 +315,7 @@ and
 			</tr><tr valign="TOP"><td width="115" height="8">
 					<p>
 					[[Value]]
-					
+
 					</p>
 				</td>
 				<td width="134">
@@ -331,7 +331,7 @@ and
 			</tr><tr valign="TOP"><td width="115" height="17">
 					<p>
 					[[Writable]]
-					
+
 					</p>
 				</td>
 				<td width="134">
@@ -896,7 +896,7 @@ and
 	[[DefineOwnProperty]] internal method of a host object must not
 	permit the addition of a new property to a host object if the
 	[[Extensible]] internal property of that host object has been
-	observed by ECMAScript code to be <b>false</b>. 
+	observed by ECMAScript code to be <b>false</b>.
 	</p>
 	<p>
 	If
@@ -1461,7 +1461,7 @@ and
 	<dfn id="property-identifier">Property Identifier</dfn> type is used to associate a property name with a
 	Property Descriptor.  Values of the Property Identifier type are
 	pairs of the form (name, descriptor), where name is a String and
-	descriptor is a Property Descriptor value. 
+	descriptor is a Property Descriptor value.
 	</p>
 	<p>
 	The
@@ -2123,7 +2123,7 @@ and
 		</li>
 		<li><p>
 		If
-		<a href="x9.html#x9.11">IsCallable</a>(<i>valueOf)</i> is <b>true</b> then, 
+		<a href="x9.html#x9.11">IsCallable</a>(<i>valueOf)</i> is <b>true</b> then,
 		</p>
 		<ol><li><p>
 			Let
@@ -2293,7 +2293,7 @@ and
 		have different results, then</p>
 		<ol><li><p>
 			<a href="#reject-DefineOwnProperty">Reject</a>,
-			if the [[Configurable]] field of <i>current</i> is <b>false</b>. 
+			if the [[Configurable]] field of <i>current</i> is <b>false</b>.
 			</p>
 			</li>
 			<li><p>
@@ -2336,7 +2336,7 @@ and
 					<a href="#reject-DefineOwnProperty">Reject</a>,
 					if the [[Value]] field of <i>Desc</i> is present and
 					<a href="x9.html#x9.12">SameValue</a>(<i>Desc</i>.[[Value]], <i>current</i>.[[Value]]) is
-					<b>false</b>. 
+					<b>false</b>.
 					</p>
 				</li></ol></li></ol></li>
 			<li><p>

--- a/x9.html
+++ b/x9.html
@@ -164,7 +164,7 @@
 					<p>
 					The
 					result is <b>false</b> if the argument is <b>+0</b>, <span class="symbol"><b>&#8722;</b></span><b>0</b>,
-					or <b>NaN</b>; otherwise the result is <b>true</b>. 
+					or <b>NaN</b>; otherwise the result is <b>true</b>.
 					</p>
 				</td>
 			</tr><tr valign="TOP"><td width="138">


### PR DESCRIPTION
Diff without whitespace changes: https://github.com/es5/es5.github.com/pull/16/files?w=1

(My editor automatically removed trailing whitespace at the end of each line.)
