### PR TITLE
x15.7.4.5: Move dangling open paren into <code>

### DIFF
--- a/x15.7.html
+++ b/x15.7.html
@@ -339,9 +339,9 @@
 	digits to distinguish the number from adjacent number values. For
 	example,
 	</p>
-	<p class="sp">(<code><b>1000000000000000128).toString()</b></code>
+	<p class="sp"><code><b>(1000000000000000128).toString()</b></code>
 	returns <code><b>"1000000000000000100"</b></code>,<br>while
-	(<code><b>1000000000000000128).toFixed(0)</b></code>
+	<code><b>(1000000000000000128).toFixed(0)</b></code>
 	returns <code><b>"</b></code><code><b>1000000000000000128"</b></code>.</p>
 	<h5 id="x15.7.4.6">15.7.4.6 Number.prototype.toExponential (fractionDigits) <a href="#x15.7.4.6">#</a> <a href="#x15.7.4.6-toc" class="bak">&#9417;</a> <b class="erra">&#9402;</b> <b class="rev1">&#9312;</b> <b class="anno">&#9398;</b></h5>
 	<p>


### PR DESCRIPTION
Before it rendered like this:

https://es5.github.io/#x15.7.4.5:

> NOTE The output of `toFixed` may be more precise than `toString` for some values because toString only prints enough significant digits to distinguish the number from adjacent number values. For example,
> 
> (`1000000000000000128).toString()` returns `"1000000000000000100"`,
> while (`1000000000000000128).toFixed(0)` returns `"1000000000000000128"`.
